### PR TITLE
New Rust Admin Commands page

### DIFF
--- a/de/rust_commands.md
+++ b/de/rust_commands.md
@@ -1,0 +1,85 @@
+---
+id: rust_commands
+title: Rust: Admin Befehle
+description: Informationen zu Admin Befehle für Rust von ZAP-Hosting - ZAP-Hosting.com Dokumentationen
+sidebar_label: Admin Befehle
+---
+
+Rust verfügt über eine Vielzahl verschiedener Befehle, die von Serverbesitzern und Spielern verwendet werden können. Auf dieser Seite fassen wir die nützlichsten und beliebtesten zusammen, die für Servereinstellungen, Spielerverwaltung und zur Kontrolle von Spielern verwendet werden.
+
+> Einige Befehle erfordern die Verwendung der Steam64-ID eines Spielers. Verwenden Sie die kleine Anleitung unten, um zu verstehen, wie man die Steam-ID eines Spielers erhält.
+
+## Deine Steam ID erhalten
+Erstens, verwenden Sie ein Tool wie das [Steam ID Finder](https://steamidfinder.com/) um Ihre Steam64 ID.
+
+Hier geben Sie Ihre Steam URL:
+
+![image](https://user-images.githubusercontent.com/13604413/159179966-154bb929-edcc-42aa-965e-cb747bb463f8.png)
+
+Dann drücken Sie `Find Steam ID`. Jetzt sollten wir unser Steam-Profil sehen können, hier kopieren wir unsere "Steam64ID (Dec)".
+
+Und das war's, jetzt hast du die Steam64 ID und kannst sie für die Befehle verwenden, die eine Steam64 ID below.
+
+## Befehl Kategorien
+
+Verwenden Sie die Registerkarten unten, um zwischen den einzelnen Kategorien zu wechseln. Die Tabellen bestehen aus dem Befehl selbst, den akzeptierten Werten für den Befehl (falls zutreffend) und einer Beschreibung, um das Verständnis zu erleichtern.
+
+> Jeder Befehl, der auf dieser Seite erwähnt wird, ist für Vanilla Rust.
+
+<!--DOCUSAURUS_CODE_TABS-->
+
+<!--Server-Einstellungen-->
+
+| Command Syntax                  | Accepted Values | Description | 
+| ----------------------- | ---------- | --------- | 
+| server.globalchat      | true/false          | Bei true wird jede Chat-Nachricht allen Spielern angezeigt         | 
+| server.stop      | -          | Stoppt den Server         | 
+| server.save      | -          | Speichert den Server         | 
+| server.saveinterval "value"      | Integer (default 60)          | Legt das Intervall für die automatische Speicherung für Ihren Server fest (in Sekunden)         | 
+| server.secure      | true/false          | Wenn diese Option aktiviert ist, verweigert Easy Anti Cheat (EAC) unregistrierten oder gesperrten Spielern die Verbindung, bevor sie sich verbinden.         | 
+| server.seed "value"     | Integer (e.g. 123456)          | Setzen Sie den Seed-Wert für die Serverwelt         | 
+| server.stability      | true/false          | Wenn echte Strukturstabilität für Gebäude aktiviert ist         | 
+| server.tickrate "rate"      | Integer (default 30)          | Legt die Tickrate für Ihren Server fest         | 
+| server.writecfg      | -          | Speichert Konfigurationsänderungen, die zuvor durch andere Serverbefehle festgelegt wurden         | 
+| chat.serverlog      | true/false          | Bei true wird der Chat immer in der Server-Konsole protokolliert         | 
+| commands.echo "text"      | String (e.g. "Hello World!")          | Druckt die angegebene Nachricht auf der Serverkonsole         | 
+| global.say "message"      | String (e.g. "Welcome!")          | Sendet eine Nachricht an alle Spieler des Servers         | 
+| env.time      | Integer (e.g. 16)          | Setzt die Weltzeit im Spiel auf den angegebenen Wert (in Stunden)         | 
+| server.events      | -          | Bei "true" werden Serverereignisse wie Airdrops aktiviert.         | 
+| commands.find "command"      | String (e.g. "quit")          | Suche nach einem Befehl oder mit "." werden alle verfügbaren Befehle aufgelistet         | 
+| global.quit      | -          | Speichert den Server und hält ihn dann an         | 
+| global.init      | -          | Konfigurationsdateien laden         | 
+
+<!--Spieler-Verwaltung-->
+
+| Command Syntax                  | Accepted Values | Description | 
+| ----------------------- | ---------- | --------- | 
+| global.ban "playername" "reason"      | String (e.g. "Jacob"), String (e.g. "Was naughty!")          | Verbannt einen Benutzer vom Server (mit optionalem Grund)         | 
+| global.banid "steam64"      | Integer          | Bannt einen Benutzer über seine Steam 64 ID         | 
+| global.banlistex      | -          | Gibt eine Liste der gesperrten Benutzer mit ihrem Spielernamen und dem Sperrgrund zurück         | 
+| global.banlist      | -          | Gibt eine Liste der gesperrten Spieler im Chat zurück         | 
+| global.unban "steam64"      | Integer          | Hebt die Sperrung eines Benutzers über seine Steam 64 ID auf         | 
+| global.kickall      | -          | Schmeißt alle Spieler vom Server         | 
+| global.kick "steam64 / playername" "reason"      | Integer/String (e.g. "Jacob"), String (e.g. "Was naughty!")         | Schmeißt einen Benutzer über seine Steam 64 ID oder seinen Spielernamen vom Server (mit optionalem Grund)         | 
+| global.ownerid "steam64 / playername"      | Integer/String (e.g. "Jacob")          | Setzt den angegebenen Spieler über seine Steam 64 ID oder seinen Spielernamen als Server-Administartor (Auth-Level 2)         | 
+| global.removeowner "steam64"      | Integer         | Entfernt die Administartor-Rechte des Benutzers über die angegebene Steam 64 ID         | 
+| global.moderatorid "steam64 / playername"      | Integer/String (e.g. "Jacob")          | Setzt den angegebenen Spieler als Server-Moderator durch seine Steam 64 ID oder seinen Spielernamen (Auth-Level 1)         | 
+| global.removemoderator "steam64"      | Integer          | Entfernt die Moderatorenrechte des Benutzers über die angegebene Steam 64 ID         | 
+| global.listid      | -          | Gibt eine Liste von Benutzern zurück, die über Steam 64 ID gebannt wurden          | 
+
+<!--Spieler-Steuerungen-->
+
+| Command Syntax                  | Accepted Values | Description | 
+| ----------------------- | ---------- | --------- | 
+| global.kill      | -          | Töte deinen eigenen Spieler         | 
+| global.quit      | -          | Speichert und verlässt das Spiel         | 
+| global.respawn      | -          | Respawnt deinen Spieler         | 
+| global.respawn_sleepingbag      | -          | Bringt den Spieler in den Schlafsack zurück         | 
+| player.sleep      | -          | Zwingen Sie Ihren Player zum Einschlafen         | 
+| player.wakeup      | -          | Aufwachen des Spielers erzwingen         | 
+| commands.find "command"      | String (e.g. "quit")          | Sucht nach einem Befehl, der für den Spieler verfügbar ist
+| chat.say "text"     | String (e.g. "Hello World!")          | Sendet eine Nachricht an alle Spieler des Servers         | 
+| inventory.give "itemID" "amount"     | Integer (itemID), Integer (e.g. 5)          | Fügt einen Gegenstand in Ihr Inventar ein         | 
+| inventory.giveto "playername" "itemID" "amount"      | String (e.g. "Jacob"), Integer (itemID), Integer (e.g. 5)          | Gibt einen Gegenstand an das Inventar des angegebenen Benutzers         | 
+
+<!--END_DOCUSAURUS_CODE_TABS-->

--- a/en/rust_commands.md
+++ b/en/rust_commands.md
@@ -1,0 +1,85 @@
+---
+id: rust_commands
+title: Rust: Admin Commands
+description: Information on Admin commands for Rust from ZAP-Hosting - ZAP-Hosting.com documentation
+sidebar_label: Admin Commands
+---
+
+Rust has a wide range of different commands available for server owners and players to use. On this page, we summarise the most useful and popular ones which are used for server settings, player administrating and to control players.
+
+> Some commands require the use of a player's Steam64 ID. Use the small tutorial below to understand how to get a player's Steam ID.
+
+## Getting your Steam ID
+Firstly, use use a tool like the [Steam ID Finder](https://steamidfinder.com/) to get your Steam64 ID.
+
+Here you enter your Steam URL:
+
+![image](https://user-images.githubusercontent.com/13604413/159179966-154bb929-edcc-42aa-965e-cb747bb463f8.png)
+
+Then press `Find Steam ID`. Now we should be able to see our Steam Profile, here we copy our "Steam64ID (Dec)".
+
+And that is it, now you have the Steam64 ID and can use it for the commands which require Steam64 ID below.
+
+## Command Categories
+
+Use the section tabs below to switch between each category. The tables consist of the command itself, the accepted values for the command (if applicable) and a description to make it easier to understand.
+
+> Any command which is mentioned on this page is for vanilla Rust.
+
+<!--DOCUSAURUS_CODE_TABS-->
+
+<!--Server Settings-->
+
+| Command Syntax                  | Accepted Values | Description | 
+| ----------------------- | ---------- | --------- | 
+| server.globalchat      | true/false          | When true any chat message will be shown to all players         | 
+| server.stop      | -          | Stops the server         | 
+| server.save      | -          | Saves the server         | 
+| server.saveinterval "value"      | Integer (default 60)          | Sets the auto-save interval for your server (in seconds)         | 
+| server.secure      | true/false          | When true Easy Anti Cheat (EAC) will refuse connection to any unregistered or banned players before they connect         | 
+| server.seed "value"     | Integer (e.g. 123456)          | Set the seed value for the server world         | 
+| server.stability      | true/false          | When true structure stability for buildings is enabled         | 
+| server.tickrate "rate"      | Integer (default 30)          | Sets the tick rate for your server         | 
+| server.writecfg      | -          | Saves configuration changes which have been previously set through other server commands         | 
+| chat.serverlog      | true/false          | When true chat will always be logged into the server console         | 
+| commands.echo "text"      | String (e.g. "Hello World!")          | Prints the specified message to the server console         | 
+| global.say "message"      | String (e.g. "Welcome!")          | Sends a message to all players in the server         | 
+| env.time      | Integer (e.g. 16)          | Sets the in-game world time to specified value (in hours)         | 
+| server.events      | -          | When true it enables server events such as airdrops         | 
+| commands.find "command"      | String (e.g. "quit")          | Searches for a command or using "." will list all available commands         | 
+| global.quit      | -          | Saves the server and then stops it         | 
+| global.init      | -          | Load configuration files         | 
+
+<!--Player Admin-->
+
+| Command Syntax                  | Accepted Values | Description | 
+| ----------------------- | ---------- | --------- | 
+| global.ban "playername" "reason"      | String (e.g. "Jacob"), String (e.g. "Was naughty!")          | Bans a user from the server (with optional reason)         | 
+| global.banid "steam64"      | Integer          | Bans a user through their Steam 64 ID         | 
+| global.banlistex      | -          | Returns a list of banned users with their playername and ban reason         | 
+| global.banlist      | -          | Returns a list of banned players within the chat         | 
+| global.unban "steam64"      | Integer          | Unbans a user through their Steam 64 ID         | 
+| global.kickall      | -          | Kicks all players from the server         | 
+| global.kick "steam64 / playername" "reason"      | Integer/String (e.g. "Jacob"), String (e.g. "Was naughty!")         | Kicks a user from the server through their Steam 64 ID or their playername (with optional reason)         | 
+| global.ownerid "steam64 / playername"      | Integer/String (e.g. "Jacob")          | Sets the specified player as a server administartor through their Steam 64 ID or their playername (Auth level 2)         | 
+| global.removeowner "steam64"      | Integer         | Removes administartor privilages from the user through the specified Steam 64 ID         | 
+| global.moderatorid "steam64 / playername"      | Integer/String (e.g. "Jacob")          | Sets the specified player as a server moderator through their Steam 64 ID or their playername (Auth level 1)         | 
+| global.removemoderator "steam64"      | Integer          | Removes moderator privilages from the user through the specified Steam 64 ID         | 
+| global.listid      | -          | Returns a list of users who have been banned via Steam 64 ID          | 
+
+<!--Player Controls-->
+
+| Command Syntax                  | Accepted Values | Description | 
+| ----------------------- | ---------- | --------- | 
+| global.kill      | -          | Kill your own player         | 
+| global.quit      | -          | Saves and quits the game         | 
+| global.respawn      | -          | Respawns your player         | 
+| global.respawn_sleepingbag      | -          | Respawns your player in your sleeping bag         | 
+| player.sleep      | -          | Force your player to go to sleep         | 
+| player.wakeup      | -          | Force your player to wakeup         | 
+| commands.find "command"      | String (e.g. "quit")          | Searches for a command which is available for the player
+| chat.say "text"     | String (e.g. "Hello World!")          | Sends a message to all players in the server         | 
+| inventory.give "itemID" "amount"     | Integer (itemID), Integer (e.g. 5)          | Gives an item to your inventory         | 
+| inventory.giveto "playername" "itemID" "amount"      | String (e.g. "Jacob"), Integer (itemID), Integer (e.g. 5)          | Gives an item to the specified user's inventory         | 
+
+<!--END_DOCUSAURUS_CODE_TABS-->

--- a/sidebars.json
+++ b/sidebars.json
@@ -508,6 +508,7 @@
         "Rust": [
             "rust_becomeadmin",
             "rust_connectrcon",
+            "rust_commands",
             "rust_plugins",
             "rust_decay"
         ],

--- a/sprachvariablen/de.json
+++ b/sprachvariablen/de.json
@@ -581,6 +581,10 @@
                 "title": "Rust: Verbindung via RCON zum Server herstellen",
                 "sidebar_label": "Connect via RCON"
             },
+            "rust_commands": {
+                "title": "Rust: Admin Befehle",
+                "sidebar_label": "Admin Befehle"
+              },
             "rust_decay": {
                 "title": "Decay verändern",
                 "sidebar_label": "Decay"

--- a/sprachvariablen/en.json
+++ b/sprachvariablen/en.json
@@ -614,6 +614,10 @@
         "title": "Rust: Connecting to the server via RCON",
         "sidebar_label": "Connect via RCON"
       },
+	    "rust_commands": {
+        "title": "Rust: Admin Commands",
+        "sidebar_label": "Admin Commands"
+      },
       "rust_decay": {
         "title": "Modify Decay",
         "sidebar_label": "Decay"


### PR DESCRIPTION
Created a new rust_commands.md page for both EN & DE, added it to the sidebar ans well as added to the sprachvariablen json files.

Note: May need a double check for DE translation as I used DeepL (requested community team member to check and edit the DE page further if necessary).