### PR TITLE
update satisfactory add mods - mod support not available more visible.

### DIFF
--- a/docs/satisfactory-addmods.md
+++ b/docs/satisfactory-addmods.md
@@ -3,12 +3,13 @@ id: satisfactory-addmods
 title: Install Mods
 sidebar_label: Install Mods
 ---
-:::info
-**WARNING**
+:::danger
+**IMPORTANT**
 
 Mods are currently not working!
+:::
 
-
+:::info
 **CAUTION**
 
 Mods are **not officially** supported by the developers, but they are tolerated!

--- a/i18n/de/docusaurus-plugin-content-docs/current/satisfactory-addmods.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/satisfactory-addmods.md
@@ -3,13 +3,14 @@ id: satisfactory-addmods
 title: Mods installieren
 sidebar_label: Mods installieren
 ---
-
-:::info
+:::danger
 **ACHTUNG**
 
 Mods sind zum aktuellen Zeitpunkt NICHT nutzbar!
+:::
 
 
+:::info
 **ACHTUNG**
 
 Mods sind von den Entwicklern bisher **nicht offiziell** unterstützt, sie werden jedoch geduldet!


### PR DESCRIPTION
A lot of customers are confused by the Guide because it makes you think satisfactory mod support is still available, even with the info message.
This update changes the info that the mod support is not available to a red one, which is hopefully better.
This will hopefully help some people to notice this important information.


~Fabian