### PR TITLE
Fix primary color text contrast in light mode

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -6,13 +6,13 @@
 
 /* You can override the default Infima variables here. */
 :root {
-  --ifm-color-primary: #18E888;
-  --ifm-color-primary-dark: #00C48B;
-  --ifm-color-primary-darker: #02a40e;
-  --ifm-color-primary-darkest: #01870c;
-  --ifm-color-primary-light: #39F1B3;
-  --ifm-color-primary-lighter: #02de14;
-  --ifm-color-primary-lightest: #28fd38;
+  --ifm-color-primary: #0D874E;
+  --ifm-color-primary-dark: #0C7946;
+  --ifm-color-primary-darker: #096D3E;
+  --ifm-color-primary-darkest: #065632;
+  --ifm-color-primary-light: #0E8B51;
+  --ifm-color-primary-lighter: #109E5B;
+  --ifm-color-primary-lightest: #11AC64;
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
   --ifm-background-color: #f9f9f9;


### PR DESCRIPTION
The very light and bright green is barely readable when used on a light background. It is even worse when the background is slightly tainted with a bit of gray, the way it's done in some hover/active states.

I've put the color into a contrast checker (https://webaim.org/resources/contrastchecker/) and adjusted the lightness until at least AA passes for smaller text (I think this happens when a level of at least 4.5 is reached). I then moved the lightness up and down a bit multiple times to create the shades. Unfortunately, I don't know where the color is used on the page, so I can't verify if this looks good/works at the places it is being used, maybe someone can shed some light on this? Potentially, they might not even be used at all?