### PR TITLE
Nest guide categories in dropdown

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -167,40 +167,41 @@ const config = {
       },
       items: [
         {
-          type: 'docSidebar',
-          sidebarId: 'guidesSidebar',
+          type: 'dropdown',
+          label: 'Guides',
           position: 'left',
-          label: 'General',
-        },
-        {
-          type: 'docSidebar',
-          sidebarId: 'gameserverSidebar',
-          position: 'left',
-          label: 'Gameserver',
-        },
-        {
-          type: 'docSidebar',
-          sidebarId: 'vpsrootSidebar',
-          position: 'left',
-          label: 'vRootserver',
-        },
-        {
-          type: 'docSidebar',
-          sidebarId: 'dedicatedserverSidebar',
-          position: 'left',
-          label: 'Dedicated Server',
-        },
-        {
-          type: 'docSidebar',
-          sidebarId: 'domainwebspaceSidebar',
-          position: 'left',
-          label: 'Domain & Webspace',
-        },
-        {
-          type: 'docSidebar',
-          sidebarId: 'voiceserverbotSidebar',
-          position: 'left',
-          label: 'Voicebot & Voiceserver',
+          items: [
+            {
+              type: 'docSidebar',
+              sidebarId: 'guidesSidebar',
+              label: 'General',
+            },
+            {
+              type: 'docSidebar',
+              sidebarId: 'gameserverSidebar',
+              label: 'Gameserver',
+            },
+            {
+              type: 'docSidebar',
+              sidebarId: 'vpsrootSidebar',
+              label: 'vRootserver',
+            },
+            {
+              type: 'docSidebar',
+              sidebarId: 'dedicatedserverSidebar',
+              label: 'Dedicated Server',
+            },
+            {
+              type: 'docSidebar',
+              sidebarId: 'domainwebspaceSidebar',
+              label: 'Domain & Webspace',
+            },
+            {
+              type: 'docSidebar',
+              sidebarId: 'voiceserverbotSidebar',
+              label: 'Voicebot & Voiceserver',
+            },
+          ],
         },
         {
           type: 'html',


### PR DESCRIPTION
The navigation currently looks something like this:

![current-navbar](https://github.com/zaphosting/docs/assets/56672951/9d9d692a-2803-4a18-8206-9e0b72df1250)

On bigger devices, the items are still kinda misplaced, and it generally has a look of being overfilled. I suggested nesting the guide categories into a dropdown. Marvin agreed.

It should now look something like this (including the color change from my other PR https://github.com/zaphosting/docs/pull/1241):

![updated-navbar](https://github.com/zaphosting/docs/assets/56672951/acd24cd8-a4bc-40a3-93f2-e35734f24c4e)
