### PR TITLE
fix(minecraft-server-optimize): typo

### DIFF
--- a/i18n/de/docusaurus-plugin-content-docs/current/minecraft-server-optimize.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/minecraft-server-optimize.md
@@ -181,7 +181,7 @@ Je nach belieben kann der Wert auch auf 4 gestellt werden, was als Beispiel sehr
 
 ### Daten-Komprimierung
 
-Auf einem Server werden permanent zwischen Server und den verbundenen Spielern ausgetauscht.
+Auf einem Server werden permanent Daten zwischen dem Server und den verbundenen Spielern ausgetauscht.
 Dabei werden etwas die Bewegungen von den Spieler selbst an den Server übertragen und der Server sendet dies dann wiederum an alle anderen Spieler.
 Aber auch Spieler-Aktionen oder Ereignisse in der Welt, wie Explosionen als Beispiel sind ein Teil der Daten, welche immer wieder übertragen werden.
 


### PR DESCRIPTION
This pull request fixes a typo in the text. The sentence 

"Auf einem Server werden permanent zwischen Server und den verbundenen Spielern ausgetauscht" 

was corrected to 

"Auf einem Server werden permanent Daten zwischen dem Server und den verbundenen Spielern ausgetauscht." 

This improves the readability and correctness of the document.