### PR TITLE
Add funnels and design improvement

### DIFF
--- a/docs/gameserver-backups.md
+++ b/docs/gameserver-backups.md
@@ -3,9 +3,13 @@ id: gameserver-backups
 title: 'Game server: Create, download and import backups'
 description: Information on how to create, download and restore backups for your game server from ZAP-Hosting -ZAP-Hosting.com 
 sidebar_label: Backups
+services:
+  - gameserver
+  - premium-storage
 ---
 
 import YouTube from '@site/src/components/YouTube/YouTube';
+import InlineVoucher from '@site/src/components/InlineVoucher';
 
 ## Introduction
 We offer the possibility to create individual backups per click. This allows you to create backups easily and without much effort as well as import them at any time later. We offer this feature for the server files of your game server as well as for the associated databases. All backups are stored on your storage server, which includes 10GB free storage space by default. If you need more, then you can also upgrade to Premium Storage.
@@ -23,7 +27,7 @@ Press the green **+** button next to the backup list to create a backup manually
 The backup creation process can take a few minutes depending on the file size of your server!
 :::
 
-
+<InlineVoucher />
 
 ## Create backups automatically
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -27,6 +27,10 @@ const config = {
   onBrokenMarkdownLinks: 'throw',
   onDuplicateRoutes: 'throw',
   onBrokenAnchors: 'throw',
+
+  customFields: {
+    marketingSite: 'https://zap-hosting.com',
+  },
   
   // Even if you don't use internalization, you can use this field to set useful
   // metadata like html lang. For example, if your site is Chinese, you may want

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -31,7 +31,7 @@ const config = {
   customFields: {
     marketingSite: 'https://zap-hosting.com',
   },
-  
+
   // Even if you don't use internalization, you can use this field to set useful
   // metadata like html lang. For example, if your site is Chinese, you may want
   // to replace "en" with "zh-Hans".

--- a/i18n/de/code.json
+++ b/i18n/de/code.json
@@ -1,4 +1,16 @@
 {
+  "Hosting Voucher": {
+    "message": "Hosting-Gutschein"
+  },
+  "YEEEAH!": {
+    "message": "YUHUU!"
+  },
+  "Rent a server": {
+    "message": "Server mieten"
+  },
+  "Redeem": {
+    "message": "Einlösen"
+  },
   "theme.ErrorPageContent.title": {
     "message": "Die Seite ist abgestürzt.",
     "description": "The title of the fallback page when the page crashed"

--- a/i18n/de/code.json
+++ b/i18n/de/code.json
@@ -1,15 +1,48 @@
 {
-  "Hosting Voucher": {
-    "message": "Hosting-Gutschein"
+  "inlinevoucher.description.without-products": {
+    "message": "Startklar für dein nächstes cooles Projekt 😉"
   },
-  "YEEEAH!": {
-    "message": "YUHUU!"
+  "inlinevoucher.list-title.without-products": {
+    "message": "Warum du uns testen solltest?"
   },
-  "Rent a server": {
+  "inlinevoucher.list-reasons.first": {
+    "message": "DDoS-Protection"
+  },
+  "inlinevoucher.list-reasons.second": {
+    "message": "Server online in Minuten"
+  },
+  "inlinevoucher.list-reasons.third": {
+    "message": "Eigenes Webinterface"
+  },
+  "voucherbox.cta": {
     "message": "Server mieten"
   },
-  "Redeem": {
+  "voucherbutton.success": {
+    "message": "JUHUUU!"
+  },
+  "inlinevoucher.title": {
+    "message": "{voucherValue} {voucherType} Hosting-Gutschein 🏷️"
+  },
+  "inlinevoucher.description.with-products": {
+    "message": "Starklar mit den Produkten aus der Anleitung 😉"
+  },
+  "inlinevoucher.list-title.with-products": {
+    "message": "Somit unter anderem gültig für:"
+  },
+  "inlinevoucher.your-voucher": {
+    "message": "Dein Gutschein"
+  },
+  "voucher.redeem": {
     "message": "Einlösen"
+  },
+  "voucherbox.title": {
+    "message": "Hosting-Gutschein"
+  },
+  "servicelist.introduction": {
+    "message": "Die Anleitung wurde mit folgenden Produkten erstellt:"
+  },
+  "servicelist.note": {
+    "message": "(Einzelheiten können sich bei Produkten anderer Anbieter unterscheiden, die Grundkonzepte bleiben in der Regel unverändert)"
   },
   "theme.ErrorPageContent.title": {
     "message": "Die Seite ist abgestürzt.",

--- a/i18n/de/docusaurus-plugin-content-docs/current/gameserver-backups.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/gameserver-backups.md
@@ -3,9 +3,13 @@ id: gameserver-backups
 title: 'Gameserver: Backups erstellen, herunterladen und einspielen'
 description: Informationen, wie du Backups für deinen Gameserver von ZAP-Hosting erstellen, herunterladen und wieder einspielen kannst -ZAP-Hosting.com Dokumentation
 sidebar_label: Backups
+services:
+  - gameserver
+  - premium-storage
 ---
 
 import YouTube from '@site/src/components/YouTube/YouTube';
+import InlineVoucher from '@site/src/components/InlineVoucher';
 
 ## Einführung
 Wir bieten die Möglichkeit, Backups individuell per Klick zu erstellen. Dadurch können Backups kinderleicht und ohne großen Aufwand erstellt und zu einem späteren Zeitpunkt jederzeit wieder importiert werden. Dieses Feature bieten wir sowohl für die Server-Dateien deines Gameserver als auch für die dazugehörigen Datenbanken. Das Backup wird dann auf deinem Storage Server gespeichert, welcher standardmäßig 10 GB kostenlosen Speicherplatz bietet. Solltest du mehr benötigen, dann kannst du auch auf ein Premium Storage upgraden.
@@ -23,7 +27,7 @@ Um ein Backup manuell zu erstellen, muss der grüne **+** Button neben der Backu
 Je nach Speichergröße des Servers kann das Anlegen des Backups durchaus ein paar Minuten dauern!
 :::
 
-
+<InlineVoucher />
 
 ## Backup automatisiert erstellen
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "docusaurus-lunr-search": "^3.3.2",
         "prism-react-renderer": "^2.2.0",
         "react": "^18.3.1",
+        "react-copy-to-clipboard": "^5.1.0",
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
@@ -5263,6 +5264,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/copy-to-clipboard": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
+      "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
+      "dependencies": {
+        "toggle-selection": "^1.0.6"
       }
     },
     "node_modules/copy-webpack-plugin": {
@@ -13016,6 +13025,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-copy-to-clipboard": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/react-copy-to-clipboard/-/react-copy-to-clipboard-5.1.0.tgz",
+      "integrity": "sha512-k61RsNgAayIJNoy9yDsYzDe/yAZAzEbEgcz3DZMhF686LEyukcE1hzurxe85JandPUG+yTfGVFzuEw3xt8WP/A==",
+      "dependencies": {
+        "copy-to-clipboard": "^3.3.1",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": "^15.3.0 || 16 || 17 || 18"
+      }
+    },
     "node_modules/react-dev-utils": {
       "version": "12.0.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.1.tgz",
@@ -15205,6 +15226,11 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ=="
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "docusaurus-lunr-search": "^3.3.2",
     "prism-react-renderer": "^2.2.0",
     "react": "^18.3.1",
+    "react-copy-to-clipboard": "^5.1.0",
     "react-dom": "^18.3.1"
   },
   "devDependencies": {

--- a/src/components/InlineVoucher/index.tsx
+++ b/src/components/InlineVoucher/index.tsx
@@ -1,0 +1,231 @@
+import styles from './styles.module.css';
+import Translate from '@docusaurus/Translate';
+import { mapList } from '../../utilities/serviceMapper';
+import VoucherButton from '../VoucherButton';
+import { VoucherContext } from '../../utilities/contexts/VoucherContext';
+import { useContext } from 'react';
+import { useDoc } from '@docusaurus/theme-common/internal';
+
+export default function InlineVoucher({ showProducts = true }): JSX.Element {
+  const { frontMatter } = useDoc();
+
+  const { loading, voucher, found } = useContext(VoucherContext);
+
+  let services = null;
+  let serviceInfoList = [];
+
+  if (
+    frontMatter.hasOwnProperty('services')
+    && Array.isArray(frontMatter.services)
+    && frontMatter.services.length > 0
+  ) {
+    services = frontMatter.services;
+    serviceInfoList = mapList(services);
+  }
+
+  const canDisplayProducts = showProducts === true && serviceInfoList.length > 0;
+
+  return (
+    <>
+      {loading === true ? (
+        <div className={styles.loader}>
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" style={{
+            width: "15px",
+            height: "15px",
+          }} className="spinner">
+            <path fillRule="evenodd"
+                  d="M13.836 2.477a.75.75 0 0 1 .75.75v3.182a.75.75 0 0 1-.75.75h-3.182a.75.75 0 0 1 0-1.5h1.37l-.84-.841a4.5 4.5 0 0 0-7.08.932.75.75 0 0 1-1.3-.75 6 6 0 0 1 9.44-1.242l.842.84V3.227a.75.75 0 0 1 .75-.75Zm-.911 7.5A.75.75 0 0 1 13.199 11a6 6 0 0 1-9.44 1.241l-.84-.84v1.371a.75.75 0 0 1-1.5 0V9.591a.75.75 0 0 1 .75-.75H5.35a.75.75 0 0 1 0 1.5H3.98l.841.841a4.5 4.5 0 0 0 7.08-.932.75.75 0 0 1 1.025-.273Z"
+                  clipRule="evenodd"/>
+          </svg>
+        </div>
+      ) : (
+        <>
+          {found === true &&
+            <>
+              <div className={styles.wiggleBg + ' wiggle-bg'} style={{
+                'height': '7rem',
+                'margin': '0 1rem',
+                'position': 'relative',
+              }}>
+                <div className={styles.backgroundFader}></div>
+              </div>
+              <div className="relative">
+                <div className={styles.sibblingCard}></div>
+                <div className={styles.sibblingCard}></div>
+                <div className={styles.sibblingCard}></div>
+                <div className={styles.sibblingCard}></div>
+                <div className={styles.box}>
+                  <div className={styles.informationArea}>
+                    <span className={styles.title}>
+                        <Translate id="inlinevoucher.title" values={{
+                          voucherType: voucher.type,
+                          voucherValue: voucher.value,
+                        }}>
+                            {'{voucherValue} {voucherType} Hosting Voucher 🏷️'}
+                        </Translate>
+                    </span>
+                    {canDisplayProducts === true &&
+                      <>
+                        <p className={[styles.description, styles.mtsmall].join(' ')}>
+                          <Translate id="inlinevoucher.description.with-products">
+                            Ready to go with all products used in the guide 😉
+                          </Translate>
+                        </p>
+                        <p className={[styles.descriptionSmall, styles.mtbig].join(' ')}>
+                          <Translate id="inlinevoucher.list-title.with-products">
+                            Therefore also applicable for:
+                          </Translate>
+                        </p>
+                        <div className={[styles.detailList, styles.mtmedium].join(' ')}>
+                          {serviceInfoList.map((serviceDetails, index) => (
+                            <a href={serviceDetails.url} target="_blank" key={index} className={styles.item}>
+                              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"
+                                     className={styles.icon}>
+                                  <path fillRule="evenodd"
+                                          d="M16.403 12.652a3 3 0 0 0 0-5.304 3 3 0 0 0-3.75-3.751 3 3 0 0 0-5.305 0 3 3 0 0 0-3.751 3.75 3 3 0 0 0 0 5.305 3 3 0 0 0 3.75 3.751 3 3 0 0 0 5.305 0 3 3 0 0 0 3.751-3.75Zm-2.546-4.46a.75.75 0 0 0-1.214-.883l-3.483 4.79-1.88-1.88a.75.75 0 1 0-1.06 1.061l2.5 2.5a.75.75 0 0 0 1.137-.089l4-5.5Z"
+                                          clipRule="evenodd"/>
+                              </svg>
+                              <span className={styles.text}>
+                                {serviceDetails.title}
+                              </span>
+                            </a>
+                          ))}
+                        </div>
+                      </>
+                    }
+                    {canDisplayProducts === false &&
+                      <>
+                        <p className={[styles.description, styles.mtsmall].join(' ')}>
+                          <Translate id="inlinevoucher.description.without-products">
+                            Ready for your next awesome project 😉
+                          </Translate>
+                        </p>
+                        <p className={[styles.descriptionSmall, styles.mtbig].join(' ')}>
+                          <Translate id="inlinevoucher.list-title.without-products">
+                            Why you should give us a try?
+                          </Translate>
+                        </p>
+                        <div className={[styles.detailList, styles.mtmedium].join(' ')}>
+                          <div className={styles.item}>
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"
+                                   className={styles.icon}>
+                                <path fillRule="evenodd"
+                                        d="M16.403 12.652a3 3 0 0 0 0-5.304 3 3 0 0 0-3.75-3.751 3 3 0 0 0-5.305 0 3 3 0 0 0-3.751 3.75 3 3 0 0 0 0 5.305 3 3 0 0 0 3.75 3.751 3 3 0 0 0 5.305 0 3 3 0 0 0 3.751-3.75Zm-2.546-4.46a.75.75 0 0 0-1.214-.883l-3.483 4.79-1.88-1.88a.75.75 0 1 0-1.06 1.061l2.5 2.5a.75.75 0 0 0 1.137-.089l4-5.5Z"
+                                        clipRule="evenodd"/>
+                            </svg>
+                            <span className={styles.text}>
+                              <Translate id="inlinevoucher.list-reasons.first">
+                                DDoS-Protection
+                              </Translate>
+                            </span>
+                          </div>
+                          <div className={styles.item}>
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"
+                                   className={styles.icon}>
+                                <path fillRule="evenodd"
+                                        d="M16.403 12.652a3 3 0 0 0 0-5.304 3 3 0 0 0-3.75-3.751 3 3 0 0 0-5.305 0 3 3 0 0 0-3.751 3.75 3 3 0 0 0 0 5.305 3 3 0 0 0 3.75 3.751 3 3 0 0 0 5.305 0 3 3 0 0 0 3.751-3.75Zm-2.546-4.46a.75.75 0 0 0-1.214-.883l-3.483 4.79-1.88-1.88a.75.75 0 1 0-1.06 1.061l2.5 2.5a.75.75 0 0 0 1.137-.089l4-5.5Z"
+                                        clipRule="evenodd"/>
+                            </svg>
+                            <span className={styles.text}>
+                              <Translate id="inlinevoucher.list-reasons.second">
+                                Online within minutes
+                              </Translate>
+                            </span>
+                          </div>
+                          <div className={styles.item}>
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"
+                                   className={styles.icon}>
+                                <path fillRule="evenodd"
+                                        d="M16.403 12.652a3 3 0 0 0 0-5.304 3 3 0 0 0-3.75-3.751 3 3 0 0 0-5.305 0 3 3 0 0 0-3.751 3.75 3 3 0 0 0 0 5.305 3 3 0 0 0 3.75 3.751 3 3 0 0 0 5.305 0 3 3 0 0 0 3.751-3.75Zm-2.546-4.46a.75.75 0 0 0-1.214-.883l-3.483 4.79-1.88-1.88a.75.75 0 1 0-1.06 1.061l2.5 2.5a.75.75 0 0 0 1.137-.089l4-5.5Z"
+                                        clipRule="evenodd"/>
+                            </svg>
+                            <span className={styles.text}>
+                              <Translate id="inlinevoucher.list-reasons.third">
+                                Custom webinterface
+                              </Translate>
+                            </span>
+                          </div>
+                        </div>
+                      </>
+                    }
+                  </div>
+                  <div className={styles.voucherArea}>
+                    <div className="relative flex w-full">
+                      <svg className={styles.cardDecoration} style={{
+                        position: 'absolute',
+                        bottom: '-1.25rem',
+                        left: '-1.75rem',
+                        width: '1rem',
+                        transform: 'rotate(-45deg)',
+                      }} viewBox="0 0 88 190"
+                           fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+                          <path
+                              d="M43.3244 7.19516C47.5026 10.6392 51.6341 14.106 55.7657 17.5954C58.2866 19.7479 60.5975 22.1271 63.5386 23.8491C64.3322 24.3249 65.546 24.3703 65.9194 25.3219V25.2992C66.7598 25.8204 67.7168 26.2056 68.417 26.8627C71.078 29.3325 74.1825 31.553 76.4467 34.2267C76.5401 34.34 76.8435 34.2947 76.9836 34.4306C77.6838 35.0877 80.0414 37.5575 81.722 38.985C85.5968 42.2705 89.3315 45.6919 91.9458 50.2915C92.3426 51.0166 99.5553 59.5589 95.9139 63.2748C92.1325 67.1494 83.0758 61.1903 82.1888 60.1253C80.0647 57.5196 78.4308 54.3701 75.3263 52.8293C70.7746 50.5635 67.6934 46.7568 63.912 43.7206C60.5041 40.9789 57.4696 37.852 54.0384 35.133C50.8172 32.5953 46.9657 30.692 43.9546 27.905C41.3637 25.5032 39.683 22.1724 37.3955 19.4534C36.8587 18.8189 35.4581 18.8416 34.8279 18.1618C34.3144 17.5954 33.404 16.7344 33.1706 15.896C33.0773 15.5335 32.9839 15.1256 32.6337 15.0577C30.9531 14.7178 23.1802 5.88094 27.6152 1.39457C31.9102 -3.02383 39.7064 4.20425 43.3244 7.19516Z"/>
+                          <path
+                              d="M40.0772 87.0864C44.1154 88.1287 48.1535 89.2163 52.1684 90.3265C54.6426 91.0063 57.0001 92.0033 59.6378 92.1392C60.3614 92.1845 61.2717 91.6634 61.8086 92.2978C62.5789 92.3658 63.3959 92.2525 64.0961 92.5018C66.7338 93.4081 69.6749 93.8839 72.0791 95.1528C72.1725 95.1981 72.3825 95.0168 72.5226 95.0848C73.2228 95.3341 75.6504 96.3764 77.2843 96.8295C81.0657 97.8945 84.7771 99.0954 87.9516 101.86C88.4418 102.29 96.1213 106.346 94.4407 111.195C92.6901 116.248 84.3103 115.274 83.3533 114.775C81.0657 113.529 78.9883 111.558 76.2573 111.648C72.2425 111.784 68.9279 109.926 65.2632 109.042C61.972 108.249 58.8675 106.935 55.5763 106.187C52.4718 105.485 49.1105 105.598 46.1228 104.579C43.5552 103.695 41.3843 101.61 38.9568 100.319C38.3732 100.024 37.3462 100.681 36.6926 100.387C36.1557 100.138 35.2454 99.7978 34.8486 99.2087C34.6852 98.9594 34.4985 98.6422 34.2183 98.7328C32.8645 99.2087 24.6715 95.1755 26.7723 89.3069C28.803 83.529 36.5759 86.1801 40.0772 87.0864Z"/>
+                          <path
+                              d="M16.0785 169.819C21.8673 168.573 27.6561 167.395 33.4683 166.217C37.0396 165.492 40.6576 165.107 44.1122 163.815C45.0459 163.452 45.9095 162.546 46.9833 162.818H46.9599C47.9636 162.455 48.944 161.957 49.9711 161.776C53.8925 161.164 57.9073 160.008 61.7588 159.827C61.8988 159.827 62.0622 159.555 62.2956 159.51C63.346 159.351 67.0807 158.966 69.4383 158.49C74.9003 157.403 80.3857 156.474 86.1512 157.153C87.0615 157.267 99.3394 156.678 100.203 161.73C101.113 166.987 89.8859 170.59 88.3453 170.635C84.6573 170.771 80.8058 170.182 77.3746 171.7C72.356 173.921 66.9874 174.102 61.7821 175.257C57.1137 176.3 52.3519 176.844 47.6835 177.931C43.3186 178.951 39.0937 180.854 34.6587 181.557C30.8306 182.168 26.7691 181.511 22.871 181.692C21.9607 181.738 21.027 182.848 20.0466 182.939C19.2296 183.007 17.8525 183.211 16.9655 182.893C16.592 182.757 16.1718 182.576 15.8684 182.825C14.4445 183.958 1.5364 184.819 0.509357 178.679C-0.447665 172.742 11.0599 170.907 16.0785 169.819Z"/>
+                      </svg>
+                      <svg className={styles.cardDecoration} style={{
+                        position: 'absolute',
+                        right: '-1.25rem',
+                        top: '-.75rem',
+                        width: '1rem',
+                        transform: 'rotate(-12deg)',
+                      }} viewBox="0 0 88 190"
+                           fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+                          <path
+                              d="M11.4101 14.8736C15.7751 13.4688 20.1867 12.1093 24.575 10.7724C27.2827 9.95672 30.0604 9.45823 32.6046 8.07606C33.3049 7.69087 33.8418 6.76184 34.7054 6.98843H34.6821C35.429 6.60323 36.1293 6.05945 36.9229 5.87819C39.9107 5.15312 42.9218 3.88422 45.9096 3.58966C46.0263 3.567 46.1196 3.31776 46.283 3.27244C47.0767 3.09118 49.9711 2.5927 51.7451 2.0489C55.8766 0.802686 60.0548 -0.284915 64.6765 0.213571C65.4001 0.281547 74.947 -0.670124 76.3008 4.26942C77.7014 9.43555 69.3683 13.3328 68.1778 13.4235C65.3068 13.6727 62.2023 13.2195 59.728 14.8283C56.0867 17.1848 51.9085 17.5246 47.987 18.8388C44.4624 20.0171 40.7977 20.6968 37.2964 21.9204C34.0052 23.076 30.9474 25.0699 27.5628 25.9083C24.645 26.6333 21.3771 26.1122 18.3427 26.4067C17.6191 26.4747 17.0589 27.6076 16.2886 27.7209C15.6583 27.8116 14.6079 28.0608 13.861 27.7889C13.5342 27.6756 13.2074 27.517 12.9973 27.7663C12.0403 28.9218 2.00326 30.1907 0.416004 24.1635C-1.17125 18.2723 7.6287 16.0972 11.4101 14.8736Z"/>
+                          <path
+                              d="M25.7628 81.5368C29.6609 81.3782 33.5357 81.2649 37.4338 81.1743C39.8147 81.129 42.1956 81.4009 44.5998 80.7665C45.2534 80.5852 45.9303 79.8374 46.5839 80.3133C47.2841 80.1547 47.9844 79.8148 48.6613 79.8601C51.2756 79.9734 54.0066 79.5882 56.5042 80.1094C56.5976 80.132 56.7376 79.9054 56.8777 79.9054C57.578 79.9508 60.0289 80.2453 61.6161 80.2227C65.2808 80.1547 68.9222 80.2453 72.5168 81.9674C73.077 82.2393 81.0367 83.8933 80.8966 89.0368C80.7565 94.3615 73.0304 95.8343 72.05 95.6304C69.6691 95.0866 67.2649 93.7951 64.8607 94.6788C61.336 95.9476 57.8581 95.1319 54.3568 95.3358C51.2056 95.5171 48.0778 95.1546 44.9499 95.3812C42.0088 95.5851 39.0211 96.6727 36.08 96.5594C33.5357 96.4461 31.0381 95.0639 28.4938 94.5428C27.8869 94.4068 27.1633 95.3585 26.5098 95.2452C25.9729 95.1546 25.0625 95.1093 24.549 94.6561C24.3156 94.4522 24.0822 94.2029 23.8488 94.3842C22.775 95.2226 14.3719 93.7271 14.582 87.496C14.722 81.3782 22.3782 81.6728 25.7628 81.5368Z"/>
+                          <path
+                              d="M23.3431 158.421C28.0815 159.689 32.8199 161.004 37.535 162.34C40.4294 163.156 43.2071 164.312 46.2883 164.561C47.1286 164.629 48.1556 164.153 48.8092 164.833H48.7859C49.6729 164.924 50.6066 164.878 51.4469 165.15C54.5514 166.215 57.9826 166.849 60.8304 168.254C60.9471 168.3 61.1805 168.141 61.3439 168.209C62.1609 168.504 65.0319 169.682 66.9693 170.226C71.4043 171.494 75.7692 172.922 79.6207 175.89C80.2276 176.343 89.3309 180.875 87.6503 185.724C85.8763 190.777 76.1427 189.372 75.0223 188.783C72.2913 187.401 69.7937 185.293 66.6425 185.225C61.9974 185.158 58.0527 183.096 53.7811 182.008C49.9296 181.034 46.265 179.538 42.4135 178.609C38.7955 177.726 34.874 177.68 31.3494 176.502C28.3149 175.482 25.7006 173.239 22.8062 171.789C22.1293 171.449 20.9622 172.061 20.1919 171.744C19.5617 171.472 18.488 171.087 17.9978 170.452C17.7877 170.18 17.5776 169.863 17.2275 169.954C15.6869 170.384 5.97664 165.853 8.07742 159.961C10.0848 154.229 19.2349 157.333 23.3431 158.421Z"/>
+                      </svg>
+                      <div className={styles.voucherSibblingCard}></div>
+                      <div className={styles.voucherSibblingCard}></div>
+                      <div className={styles.voucherCard}>
+                        <span className={styles.voucherLabel}>
+                          <Translate id="inlinevoucher.your-voucher">
+                            YOUR voucher
+                          </Translate>
+                        </span>
+                        <div className={styles.mbhuge}>
+                          <VoucherButton code={voucher.code} small={true}></VoucherButton>
+                        </div>
+                        <div className={styles.cutLine}></div>
+                        <a href="#" className={styles.footer} target="_blank">
+                          <span
+                            className={styles.text}>
+                            <Translate id="voucher.redeem">
+                              Redeem
+                            </Translate>
+                          </span>
+                          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"
+                               fill="currentColor"
+                               className={styles.icon}>
+                              <path fillRule="evenodd"
+                                    d="M6.22 4.22a.75.75 0 0 1 1.06 0l3.25 3.25a.75.75 0 0 1 0 1.06l-3.25 3.25a.75.75 0 0 1-1.06-1.06L8.94 8 6.22 5.28a.75.75 0 0 1 0-1.06Z"
+                                    clipRule="evenodd"/>
+                          </svg>
+                        </a>
+                      </div>
+                    </div>
+                    </div>
+                  </div>
+                </div>
+              <div className={styles.wiggleBg + ' wiggle-bg'} style={{
+                'height': '7rem',
+                'margin': '0 1rem',
+                'position': 'relative',
+              }}>
+                <div className={styles.backgroundFader} style={{
+                  'transform': 'rotate(180deg)',
+                }}></div>
+              </div>
+            </>
+          }
+        </>
+      )}
+    </>
+  )
+}

--- a/src/components/InlineVoucher/styles.module.css
+++ b/src/components/InlineVoucher/styles.module.css
@@ -1,0 +1,379 @@
+.box {
+    position: relative;
+    z-index: 10;
+    display: flex;
+    column-gap: 2.5rem;
+    border-radius: 1.5rem;
+    border: 1px solid rgb(132 204 22 / .25);
+    background-image: linear-gradient(to top right, #dcfce7, #ecfccb);
+    padding: 2.5rem 3rem;
+    box-shadow: 0 20px 25px -5px rgb(21 128 61 / .1), 0 8px 10px -6px rgb(21 128 61 / .1);
+}
+
+[data-theme='dark'] .box {
+    background-image: linear-gradient(to top right, rgb(38 38 38 / .4), #262626);
+    border: 1px solid rgb(115 115 115 / .05);
+    box-shadow: 0 0 #000000;
+}
+
+.sibblingCard {
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+    border-radius: 1.5rem;
+    border: 1px solid rgb(132 204 22 / .2);
+    background-image: linear-gradient(to top right, #dcfce7, #ecfccb);
+}
+
+.sibblingCard:nth-of-type(1),
+.sibblingCard:nth-of-type(3) {
+    opacity: 45%;
+}
+
+.sibblingCard:nth-of-type(2),
+.sibblingCard:nth-of-type(4) {
+    opacity: 25%;
+}
+
+[data-theme='dark'] .sibblingCard {
+    display: none;
+}
+
+.sibblingCard:nth-of-type(1) {
+    transform: translate(-3.6rem, .25rem) scale(90%);
+}
+
+.sibblingCard:nth-of-type(3) {
+    transform: translate(3.6rem, .25rem) scale(90%);
+}
+
+.sibblingCard:nth-of-type(2) {
+    transform: translate(-8rem, 1.25rem) scale(75%);
+}
+
+.sibblingCard:nth-of-type(4) {
+    transform: translate(8rem, 1.25rem) scale(75%);
+}
+
+@media (max-width: 1600px) {
+    .sibblingCard:nth-of-type(1) {
+        transform: translate(0, -2rem) scale(90%);
+    }
+
+    .sibblingCard:nth-of-type(3) {
+        transform: translate(0, 2rem) scale(90%);
+    }
+
+    .sibblingCard:nth-of-type(2) {
+        transform: translate(0, -4.5rem) scale(75%);
+    }
+
+    .sibblingCard:nth-of-type(4) {
+        transform: translate(0, 4.5rem) scale(75%);
+    }
+}
+
+.informationArea {
+    flex: 1 1 0%;
+}
+
+.title {
+    font-size: 1.5rem;
+    line-height: 2rem;
+    font-weight: 700;
+    color: #14532d;
+}
+
+[data-theme='dark'] .title {
+    color: rgb(250 250 250);
+}
+
+.mtsmall {
+    margin-top: .75rem;
+}
+
+.mtmedium {
+    margin-top: 1.25rem;
+}
+
+.mtbig {
+    margin-top: 1.5rem;
+}
+
+.mbhuge {
+    margin-bottom: 2rem;
+}
+
+.description,
+.descriptionSmall {
+    line-height: 1.625;
+    color: rgb(22 101 52 / .9);
+}
+
+[data-theme='dark'] .description,
+[data-theme='dark'] .descriptionSmall {
+    color: rgb(245 245 245 / .9);
+}
+
+.descriptionSmall {
+    font-size: .875rem;
+}
+
+.detailList {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    row-gap: .75rem;
+}
+
+.detailList .item {
+    display: flex;
+    align-items: flex-start;
+}
+
+.detailList .item .icon {
+    margin-right: .75rem;
+    width: 1.25rem;
+    height: 1.25rem;
+    color: #22c55e;
+}
+
+[data-theme='dark'] .detailList .item .icon {
+    color: rgb(217 249 157 / .8);
+}
+
+.detailList .item .text {
+    font-size: 0.875rem;
+    line-height: 1.25rem;
+    color: rgb(22 101 52 / .9);
+    padding-top: 1px;
+}
+
+[data-theme='dark'] .detailList .item .text {
+    color: rgb(245 245 245 / .9);
+}
+
+.voucherArea {
+    position: relative;
+    margin-right: .5rem;
+    display: flex;
+}
+
+.voucherSibblingCard {
+    position: absolute;
+    inset: 0;
+    transform-origin: bottom;
+    background-color: white;
+    opacity: 50%;
+    border-radius: 1rem;
+    box-shadow: 0 1px 3px 0 rgb(0 0 0 / .1), 0 1px 2px -1px rgb(0 0 0 / .1);
+}
+
+[data-theme='dark'] .voucherSibblingCard {
+    opacity: 5%;
+}
+
+.voucherSibblingCard:nth-of-type(1) {
+    transform: translate(-1rem, -.5rem) rotate(-6deg) scale(85%);
+}
+
+.voucherSibblingCard:nth-of-type(2) {
+    transform: translate(1rem, -.5rem) rotate(6deg) scale(85%);
+}
+
+.cardDecoration {
+    color: rgb(190 242 100);
+}
+
+[data-theme='dark'] .cardDecoration {
+    color: rgb(190 242 100 / .2);
+}
+
+.voucherCard {
+    background-color: white;
+    position: relative;
+    z-index: 10;
+    width: 9rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    overflow: hidden;
+    border-radius: 1rem;
+    border: 1px solid rgb(190 242 100 / .6);
+    box-shadow: 0 10px 15px -3px rgb(0 0 0 / .1), 0 4px 6px -4px rgb(0 0 0 / .1);
+}
+
+[data-theme='dark'] .voucherCard {
+    backdrop-filter: blur(24px);
+    background-color: transparent;
+    background-image: linear-gradient(to top right, rgb(64 64 64 / .8), rgb(82 82 82 / .8));
+    border: 1px solid transparent;
+}
+
+[data-theme='dark'] .voucherCard:before,
+[data-theme='dark'] .voucherCard:after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    background-image: linear-gradient(to right, transparent, #a3e635, transparent);
+}
+
+[data-theme='dark'] .voucherCard:before {
+    height: 1px;
+    opacity: 20%;
+}
+
+[data-theme='dark'] .voucherCard:after {
+    height: 2px;
+    opacity: 80%;
+    filter: blur(12px);
+}
+
+.voucherCard .voucherLabel {
+    text-align: center;
+    font-weight: 700;
+    color: #365314;
+    font-size: .875rem;
+    line-height: 1.25rem;
+    padding: 1.75rem 1rem 1.5rem 1rem;
+}
+
+[data-theme='dark'] .voucherCard .voucherLabel {
+    color: rgb(247 254 231);
+}
+
+.voucherCard .cutLine {
+    position: relative;
+    margin-top: auto;
+    width: 100%;
+    border-top-width: 4px;
+    border-style: dotted;
+    border-color: rgb(217 249 157);
+    border-bottom-width: 0;
+}
+
+[data-theme='dark'] .voucherCard .cutLine {
+    border-color: rgb(82 82 82);
+}
+
+.voucherCard .cutLine:before,
+.voucherCard .cutLine:after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    border-radius: 9999px;
+    background-color: rgb(217 249 157);
+    margin-top: -1px;
+    width: 1.5rem;
+    height: 1.5rem;
+}
+
+[data-theme='dark'] .voucherCard .cutLine:before,
+[data-theme='dark'] .voucherCard .cutLine:after {
+    background-color: rgb(82 82 82);
+}
+
+.voucherCard .cutLine:before {
+    left: -1.25rem;
+}
+
+.voucherCard .cutLine:after {
+    right: -1.25rem;
+}
+
+.footer {
+    display: flex;
+    align-items: center;
+    padding: 1.5rem;
+}
+
+.footer:hover .text {
+    color: rgb(54 83 20);
+}
+
+[data-theme='dark'] .footer:hover .text {
+    color: rgb(245 245 245);
+}
+
+.footer .text {
+    font-size: .688rem;
+    color: rgb(63 98 18 / .8);
+    transition-property: color;
+    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+    transition-duration: 700ms;
+}
+
+[data-theme='dark'] .footer .text {
+    color: rgb(163 163 163);
+}
+
+.footer:hover .icon {
+    transform: translateX(.125rem);
+    color: rgb(63 98 18 / .8);
+}
+
+[data-theme='dark'] .footer:hover .icon {
+    color: rgb(229 229 229);
+}
+
+.footer .icon {
+    width: .75rem;
+    height: .75rem;
+    color: rgb(63 98 18 / .6);
+    transition-property: all;
+    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+    transition-duration: 300ms;
+    margin-left: .25rem;
+}
+
+[data-theme='dark'] .footer .icon {
+    color: rgb(115 115 115);
+}
+
+.backgroundFader {
+    position: absolute;
+    inset: 0;
+    background-image: linear-gradient(to bottom, var(--ifm-background-color), transparent);
+}
+
+.wiggleBg {
+    opacity: 75%;
+}
+
+[data-theme='dark'] .wiggleBg {
+    opacity: 10%;
+}
+
+@media (max-width: 525px) {
+    .box {
+        flex-direction: column;
+        padding: 2.5rem 5rem;
+        align-items: center;
+    }
+
+    .title {
+        font-size: 1.25rem;
+        line-height: 1.75rem;
+    }
+
+    .voucherArea {
+        display: flex;
+        margin-top: 3rem;
+        margin-right: 0;
+        width: 100%;
+        justify-content: center;
+    }
+
+    .voucherCard {
+        width: 100%
+    }
+}
+
+@media (max-width: 400px) {
+    .box {
+        padding: 2.5rem;
+    }
+}

--- a/src/components/VoucherButton/index.tsx
+++ b/src/components/VoucherButton/index.tsx
@@ -1,0 +1,52 @@
+import { useState } from 'react';
+import styles from './styles.module.css';
+import { CopyToClipboard } from 'react-copy-to-clipboard';
+import Translate from '@docusaurus/Translate';
+
+export default function VoucherButton({ code, small = false }) {
+  const [
+    voucherWasJustCopied,
+    setVoucherWasJustCopied,
+  ] = useState(false);
+
+  function codeCopyFeedback(text, result) {
+    if (result === false) {
+      return;
+    }
+
+    setVoucherWasJustCopied(true);
+
+    setTimeout(() => {
+      setVoucherWasJustCopied(false);
+    }, 1000);
+  }
+
+  return (
+    <>
+      <CopyToClipboard text={code} onCopy={codeCopyFeedback}>
+        <button type="button" className={[styles.voucherButton].join(' ') + (small ? ' ' + styles.small : '') } title={code}>
+          <span className={styles.voucherCode}>
+            {voucherWasJustCopied === false ? (
+              code
+            ) : (
+              <span>
+                <Translate id="voucherbutton.success">
+                  YEEEAH!
+                </Translate>
+              </span>
+            )}
+          </span>
+            <div className={styles.copyBox}>
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor"
+                   className={styles.icon}>
+                <path
+                      d="M5.5 3.5A1.5 1.5 0 0 1 7 2h2.879a1.5 1.5 0 0 1 1.06.44l2.122 2.12a1.5 1.5 0 0 1 .439 1.061V9.5A1.5 1.5 0 0 1 12 11V8.621a3 3 0 0 0-.879-2.121L9 4.379A3 3 0 0 0 6.879 3.5H5.5Z"/>
+                <path
+                      d="M4 5a1.5 1.5 0 0 0-1.5 1.5v6A1.5 1.5 0 0 0 4 14h5a1.5 1.5 0 0 0 1.5-1.5V8.621a1.5 1.5 0 0 0-.44-1.06L7.94 5.439A1.5 1.5 0 0 0 6.878 5H4Z"/>
+              </svg>
+            </div>
+        </button>
+      </CopyToClipboard>
+    </>
+  );
+}

--- a/src/components/VoucherButton/styles.module.css
+++ b/src/components/VoucherButton/styles.module.css
@@ -1,0 +1,68 @@
+.voucherButton {
+    display: flex;
+    cursor: pointer;
+    align-items: center;
+    justify-content: center;
+    border-width: 1px;
+    border-color: rgb(132 204 22 / .15);
+    background-color: #ECFCCB;
+    padding: .25rem .25rem .25rem .75rem;
+    font-size: 0.75rem;
+    line-height: 1rem;
+    font-weight: 700;
+    box-shadow: 0 10px 15px -3px rgb(132 204 22 / .15), 0 4px 6px -4px rgb(132 204 22 / .15);
+    border-radius: 9999px;
+    transition-property: all;
+    transition-timing-function: cubic-bezier(0.4, 0, .2, 1);
+    transition-duration: 700ms;
+}
+
+.voucherButton.small {
+    font-size: .688rem;
+}
+
+.voucherButton.small .voucherCode {
+    max-width: 4.5rem;
+}
+
+.voucherButton:hover {
+    transform: scaleX(1.05) scaleY(1.05);
+    box-shadow: 0 20px 25px -5px rgb(132 204 22 / .2), 0 8px 10px -6px rgb(132 204 22 / .2);
+}
+
+.voucherButton:active {
+    transition-duration: 150ms;
+    transform: scaleX(.95) scaleY(.95);
+}
+
+.voucherButton .voucherCode {
+    padding-right: .5rem;
+    color: #3F6212;
+    max-width: 5rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.voucherButton .copyBox {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 9999px;
+    border: 1px solid rgb(77 124 15 / .15);
+    background-color: #F7FEE7;
+    padding: .25rem;
+}
+
+.voucherButton .copyBox .icon {
+    width: .75rem;
+    height: .75rem;
+    color: #84cc16;
+    transition-property: all;
+    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+    transition-duration: 700ms;
+}
+
+.voucherButton:hover .copyBox .icon {
+    color: #4D7C0F;
+}

--- a/src/components/YouTube/YouTube.module.css
+++ b/src/components/YouTube/YouTube.module.css
@@ -1,25 +1,25 @@
-[data-theme='light'] .YouTubeContainer {
+.YouTubeContainer {
   display: flex;
   max-width: 100%;
   border-radius: 8px;
   overflow: hidden;
-  border: 1px solid lightgrey;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
-  margin: 20px 0;
+  margin: 30px 0;
+}
+
+[data-theme='light'] .YouTubeContainer {
+  border: 1px solid rgb(228 228 231 / .6);
+  box-shadow: 0 1px 3px 0 rgb(0 0 0 / .1), 0 1px 2px -1px rgb(0 0 0 / .1);
+  background-color: white;
 }
 
 [data-theme='dark'] .YouTubeContainer {
-  display: flex;
-  max-width: 100%;
-  border-radius: 8px;
-  overflow: hidden;
   border: 1px solid lightgrey;
   box-shadow: 0 4px 8px rgba(187, 185, 185, 0.3);
-  margin: 20px 0;
 }
 
 .videoContainer {
-  flex-basis: 30%;
+  width: 30%;
+  flex-shrink: 0;
 }
 
 .videoIframe {
@@ -29,13 +29,14 @@
 }
 
 .contentContainer {
-  flex-basis: 70%;
-  padding: 10px;
+  flex: 1 1 0%;
+  padding: 10px 30px;
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
   justify-content: center;
   cursor: pointer;
+  min-width: 0;
 }
 
 .title {
@@ -43,15 +44,15 @@
   font-weight: bold;
   margin: 0px 0px 10px 0px;
   text-overflow: ellipsis;
-  overflow: hidden; 
-  width: 95%;
+  overflow: hidden;
+  max-width: 95%;
   white-space: nowrap;
 }
 
 .description {
   font-size: 0.75rem;
   margin: 0;
-  width: 95%;
+  line-height: 2;
 }
 
 @media (max-width: 768px) {
@@ -61,6 +62,10 @@
 
   .videoContainer, .contentContainer {
     flex-basis: 50%;
+  }
+
+  .videoContainer {
+    width: 100%;
   }
 
   .videoIframe {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -21,12 +21,15 @@
   --ifm-h2-font-size: 1.5rem;
   --ifm-h3-font-size: 1.25rem;
   --ifm-footer-background-color: #535353;
-  --doc-sidebar-width: 250px !important;
+  --doc-sidebar-width: 300px !important;
+  --ifm-container-width-xl: var(--ifm-container-width);
+  --ifm-menu-link-sublist-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='rgb(161 161 170)' %3E%3Cpath fill-rule='evenodd' d='M9.47 6.47a.75.75 0 0 1 1.06 0l4.25 4.25a.75.75 0 1 1-1.06 1.06L10 8.06l-3.72 3.72a.75.75 0 0 1-1.06-1.06l4.25-4.25Z' clip-rule='evenodd' /%3E%3C/svg%3E%0A");
+  --menu-link-dropdown-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='rgb(113 113 122)' %3E%3Cpath fill-rule='evenodd' d='M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06Z' clip-rule='evenodd' /%3E%3C/svg%3E%0A");
 }
 
 @media (min-width: 1280px) {
   :root {
-    --ifm-spacing-horizontal: 35px;
+    --ifm-spacing-horizontal: 40px;
   }
 }
 
@@ -42,7 +45,8 @@
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
   --ifm-background-color: #181920;
   --ifm-footer-background-color: #535353;
-  --doc-sidebar-width: 250px !important;
+  --doc-sidebar-width: 300px !important;
+  --menu-link-dropdown-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='rgb(161 161 170)' %3E%3Cpath fill-rule='evenodd' d='M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06Z' clip-rule='evenodd' /%3E%3C/svg%3E%0A");
 }
 
 h1 {
@@ -71,12 +75,6 @@ table {
   display: table;
 }
 
-/* set text-align for paragrah to justify */
-p {
-  text-align: justify;
-}
-
-
 /* smaller edit button */
 .theme-edit-this-page {
   color: grey;
@@ -97,10 +95,18 @@ p {
     }
 }
 
+.theme-doc-sidebar-menu {
+  font-size: 14px;
+}
+
 .menu>.menu__list .menu__list{
   border-left: 2px solid var(--ifm-color-primary);
   padding: 0px;
   margin-left: 20px;
+}
+
+.menu__link--sublist-caret:after {
+  background: var(--ifm-menu-link-sublist-icon) 50% / 24px 24px;
 }
 
 /*.menu__link--active:not(.menu__link--sublist) {
@@ -120,6 +126,10 @@ p {
   color: var(--ifm-color-gray-600);
 }
 
+.sidebar-title:not(:first-child) {
+  margin-top: 21px;
+}
+
 .navbar__item.externalLink {
   font-weight: var(--ifm-font-weight-semibold);
   font-size: 16px;
@@ -134,8 +144,63 @@ p {
   color: var(--ifm-navbar-link-hover-color);
 }
 
+.navbar_link {
+  position: relative;
+}
+
+.dropdown > .navbar__link {
+  padding-right: 16px;
+}
+
+.dropdown > .navbar__link::after {
+  border: 0;
+  background-image: var(--menu-link-dropdown-icon);
+  background-position: center;
+  background-size: 24px;
+  width: 14px;
+  height: 14px;
+  top: 50% !important;
+  margin-top: 2px;
+  margin-left: 8px;
+  position: absolute;
+}
+
 .theme-doc-toc-desktop {
   position: relative !important;
   top: auto !important;
   max-height: calc(50vh - (var(--ifm-navbar-height) + 2rem)) !important;
+}
+
+.theme-doc-breadcrumbs {
+  margin-top: 13px !important;
+}
+
+.relative {
+  position: relative;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.spinner {
+  animation: spin 1s linear infinite;
+}
+
+.wiggle-bg {
+  background-image: url("data:image/svg+xml,%3Csvg width='52' height='26' viewBox='0 0 52 26' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%2386efac' fill-opacity='0.4'%3E%3Cpath d='M10 10c0-2.21-1.79-4-4-4-3.314 0-6-2.686-6-6h2c0 2.21 1.79 4 4 4 3.314 0 6 2.686 6 6 0 2.21 1.79 4 4 4 3.314 0 6 2.686 6 6 0 2.21 1.79 4 4 4v2c-3.314 0-6-2.686-6-6 0-2.21-1.79-4-4-4-3.314 0-6-2.686-6-6zm25.464-1.95l8.486 8.486-1.414 1.414-8.486-8.486 1.414-1.414z' /%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
+  background-repeat: repeat;
+}
+
+.flex {
+  display: flex;
+}
+
+.w-full {
+  width: 100%;
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -21,7 +21,13 @@
   --ifm-h2-font-size: 1.5rem;
   --ifm-h3-font-size: 1.25rem;
   --ifm-footer-background-color: #535353;
-  --doc-sidebar-width: 350px !important;
+  --doc-sidebar-width: 250px !important;
+}
+
+@media (min-width: 1280px) {
+  :root {
+    --ifm-spacing-horizontal: 35px;
+  }
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
@@ -36,7 +42,7 @@
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
   --ifm-background-color: #181920;
   --ifm-footer-background-color: #535353;
-  --doc-sidebar-width: 350px !important;
+  --doc-sidebar-width: 250px !important;
 }
 
 h1 {
@@ -126,4 +132,10 @@ p {
 }
 .navbar__item.externalLink a:hover {
   color: var(--ifm-navbar-link-hover-color);
+}
+
+.theme-doc-toc-desktop {
+  position: relative !important;
+  top: auto !important;
+  max-height: calc(50vh - (var(--ifm-navbar-height) + 2rem)) !important;
 }

--- a/src/theme/AssociatedServicesList/index.tsx
+++ b/src/theme/AssociatedServicesList/index.tsx
@@ -1,0 +1,45 @@
+import styles from './styles.module.css';
+import Translate from '@docusaurus/Translate';
+import { mapList } from '../../utilities/serviceMapper';
+
+export default function AssociatedServicesList({ services }): JSX.Element {
+  const serviceInfoList = mapList(services);
+
+  return (
+    <>
+      {serviceInfoList.length > 0 &&
+        <div className={[styles.box, styles.verticalSpace].join(' ')}>
+          <p className={styles.note}>
+            <Translate id="servicelist.introduction">
+                This guide was created with the following products:
+            </Translate>
+          </p>
+          <p className={styles.fineprint}>
+            <Translate id="servicelist.note">
+              (Details may vary with products from different providers but the main concepts remain the same)
+            </Translate>
+          </p>
+          <div className={[styles.list, styles.mtsmall].join(' ')}>
+            {serviceInfoList.map((serviceDetails, index) => (
+              <a href={serviceDetails.url} target="_blank" key={index}
+                 className={styles.service}>
+                <div
+                  className={styles.iconContainer}>
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor"
+                       className={styles.icon}>
+                    <path
+                      d="M1.75 1.002a.75.75 0 1 0 0 1.5h1.835l1.24 5.113A3.752 3.752 0 0 0 2 11.25c0 .414.336.75.75.75h10.5a.75.75 0 0 0 0-1.5H3.628A2.25 2.25 0 0 1 5.75 9h6.5a.75.75 0 0 0 .73-.578l.846-3.595a.75.75 0 0 0-.578-.906 44.118 44.118 0 0 0-7.996-.91l-.348-1.436a.75.75 0 0 0-.73-.573H1.75ZM5 14a1 1 0 1 1-2 0 1 1 0 0 1 2 0ZM13 14a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z"/>
+                  </svg>
+                </div>
+                <span
+                  className={styles.label}>
+                  {serviceDetails.title}
+                </span>
+              </a>
+            ))}
+          </div>
+        </div>
+      }
+    </>
+  );
+}

--- a/src/theme/AssociatedServicesList/styles.module.css
+++ b/src/theme/AssociatedServicesList/styles.module.css
@@ -1,0 +1,137 @@
+[data-theme='dark'] .box {
+    background-color: rgb(38 38 38);
+    border: none;
+}
+
+.box {
+    background-color: white;
+    box-shadow: 0 1px 3px 0 rgb(0 0 0 / .1), 0 1px 2px -1px rgb(0 0 0 / .1);
+    border: 1px solid rgb(228 228 231 / .6);
+    border-radius: .5rem;
+    padding: 1rem 1.75rem;
+}
+
+.verticalSpace {
+    margin: 2rem 0;
+}
+
+.mtsmall {
+    margin-top: .75rem;
+}
+
+a:hover {
+    text-decoration: none;
+}
+
+p {
+    margin-bottom: 0;
+}
+
+[data-theme='dark'] .note {
+    color: rgb(229 229 229);
+}
+
+.note {
+    font-size: 0.875rem;
+    line-height: 1.625;
+    color: #3F3F46;
+}
+
+[data-theme='dark'] .fineprint {
+    color: rgb(163 163 163);
+}
+
+.fineprint {
+    font-size: 0.75rem;
+    line-height: 1.625;
+    color: #71717A;
+}
+
+.list {
+    display: flex;
+    flex-wrap: wrap;
+    column-gap: 0.75rem;
+    row-gap: 0.5rem;
+}
+
+.service {
+    background-color: rgb(236 252 203 / .75);
+    border: 1px solid rgb(217 249 157 / .75);
+    border-radius: 0.375rem;
+    padding: .25rem .5rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.75rem;
+    line-height: 1rem;
+    transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
+    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+    transition-duration: 500ms;
+}
+
+.service:hover {
+    background-color: rgb(217 249 157 / .75);
+}
+
+[data-theme='dark'] .service {
+    background-color: rgb(132 204 22 / .05);
+    border-color: rgb(77 124 15 / .1);
+}
+
+[data-theme='dark'] .service:hover {
+    border-color: rgb(190 242 100 / .1);
+}
+
+.service .iconContainer {
+    margin-right: .5rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition-property: transform;
+    transition-timing-function: cubic-bezier(1,.01,.06,.98);
+    transition-duration: 700ms;
+}
+
+[data-theme='dark'] .service .iconContainer .icon {
+    color: rgb(190 242 100 / .4);
+}
+
+.service .iconContainer .icon {
+    width: .75rem;
+    height: .75rem;
+    color: rgb(77 124 15 / .7);
+    transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
+    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+    transition-duration: 500ms;
+}
+
+.service:hover .iconContainer {
+    transform: translateX(.125rem);
+}
+
+[data-theme='dark'] .service:hover .iconContainer .icon {
+    color: rgb(217 249 157 / .6);
+}
+
+.service:hover .iconContainer .icon {
+    color: #4D7C0F;
+}
+
+[data-theme='dark'] .service .label {
+    color: rgb(217 249 157 / .8);
+}
+
+.service .label {
+    color: #3F6212;
+    transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
+    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+    transition-duration: 500ms;
+}
+
+[data-theme='dark'] .service:hover .label {
+    color: rgb(236 252 203);
+}
+
+.service:hover .label {
+    color: #365314;
+}

--- a/src/theme/DocItem/Content/index.tsx
+++ b/src/theme/DocItem/Content/index.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import Content from '@theme-original/DocItem/Content';
+import type ContentType from '@theme/DocItem/Content';
+import type { WrapperProps } from '@docusaurus/types';
+import { useDoc } from '@docusaurus/theme-common/internal';
+import AssociatedServicesList from '../../AssociatedServicesList';
+
+type Props = WrapperProps<typeof ContentType>;
+
+export default function ContentWrapper(props: Props): JSX.Element {
+  const { frontMatter } = useDoc();
+
+  function hasAssociatedServices() {
+    return frontMatter.hasOwnProperty('services')
+      && Array.isArray(frontMatter.services)
+      && frontMatter.services.length > 0;
+  }
+
+  return (
+    <>
+      {hasAssociatedServices() === true &&
+        <AssociatedServicesList services={frontMatter.services} />
+      }
+      <Content {...props} />
+    </>
+  );
+}

--- a/src/theme/DocItem/TOC/Desktop/index.tsx
+++ b/src/theme/DocItem/TOC/Desktop/index.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import Desktop from '@theme-original/DocItem/TOC/Desktop';
 import type DesktopType from '@theme/DocItem/TOC/Desktop';
 import type {WrapperProps} from '@docusaurus/types';
-import VoucherBox from "../../../VoucherBox";
-import styles from "./styles.module.css";
+import VoucherBox from '../../../VoucherBox';
+import styles from './styles.module.css';
 
 type Props = WrapperProps<typeof DesktopType>;
 
@@ -11,7 +11,9 @@ export default function DesktopWrapper(props: Props): JSX.Element {
   return (
     <div className={styles.container}>
       <Desktop {...props} />
-      <VoucherBox />
+      <div className={styles.mtbig}>
+        <VoucherBox />
+      </div>
     </div>
   );
 }

--- a/src/theme/DocItem/TOC/Desktop/index.tsx
+++ b/src/theme/DocItem/TOC/Desktop/index.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import Desktop from '@theme-original/DocItem/TOC/Desktop';
+import type DesktopType from '@theme/DocItem/TOC/Desktop';
+import type {WrapperProps} from '@docusaurus/types';
+import VoucherBox from "../../../VoucherBox";
+import styles from "./styles.module.css";
+
+type Props = WrapperProps<typeof DesktopType>;
+
+export default function DesktopWrapper(props: Props): JSX.Element {
+  return (
+    <div className={styles.container}>
+      <Desktop {...props} />
+      <VoucherBox />
+    </div>
+  );
+}

--- a/src/theme/DocItem/TOC/Desktop/styles.module.css
+++ b/src/theme/DocItem/TOC/Desktop/styles.module.css
@@ -5,3 +5,7 @@
     overflow-y: auto;
     padding: 5px;
 }
+
+.mtbig {
+    margin-top: 2rem;
+}

--- a/src/theme/DocItem/TOC/Desktop/styles.module.css
+++ b/src/theme/DocItem/TOC/Desktop/styles.module.css
@@ -1,0 +1,7 @@
+.container {
+    position: sticky;
+    top: calc(var(--ifm-navbar-height) + 1rem);
+    max-height: calc(100vh - (var(--ifm-navbar-height) + 2rem)) !important;
+    overflow-y: auto;
+    padding: 5px;
+}

--- a/src/theme/Root.js
+++ b/src/theme/Root.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { VoucherProvider } from '../utilities/contexts/VoucherContext';
+
+export default function Root({children}) {
+    return (
+        <VoucherProvider>
+            { children }
+        </VoucherProvider>
+    );
+}

--- a/src/theme/VoucherBox/index.tsx
+++ b/src/theme/VoucherBox/index.tsx
@@ -1,81 +1,23 @@
-import { useEffect, useState } from "react";
-import styles from "./styles.module.css";
-import { CopyToClipboard } from "react-copy-to-clipboard";
-import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
-import Translate, {translate} from '@docusaurus/Translate';
+import { useContext } from 'react';
+import styles from './styles.module.css';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import Translate, { translate } from '@docusaurus/Translate';
+import { VoucherContext } from '../../utilities/contexts/VoucherContext';
+import VoucherButton from '../../components/VoucherButton';
 
 export default function VoucherBox() {
   const { siteConfig } = useDocusaurusContext();
 
-  const [
-    loadingVoucher,
-    setLoadingVoucher,
-  ] = useState(false);
-
-  const [
-    voucherInfo,
-    setVoucherInfo,
-  ] = useState({});
-
-  const [
-    voucherFound,
-    setVoucherFound,
-  ] = useState(null);
-
-  const [
-    voucherWasJustCopied,
-    setVoucherWasJustCopied,
-  ] = useState(false);
-
-  function codeCopyFeedback(text, result) {
-    console.log(text, result)
-    if (result === false) {
-      return;
-    }
-
-    setVoucherWasJustCopied(true);
-
-    setTimeout(() => {
-      setVoucherWasJustCopied(false);
-    }, 1000);
-  }
-
-  useEffect(() => {
-    const voucherRetrieval = async () => {
-      setLoadingVoucher(true);
-
-      const voucherResponse = await (
-        await fetch("https://zap-hosting.com/interface/shop/_ajax/json_getDocsCoupon.php", {
-          headers: {
-            "X-Requested-With": "XMLHttpRequest",
-          },
-        }).finally(() => {
-          setLoadingVoucher(false);
-        })
-      ).json();
-
-      if (voucherResponse.message === "ok" && voucherResponse.result === "success") {
-        setVoucherFound(true);
-        setVoucherInfo(voucherResponse.data);
-
-        return;
-      }
-
-      setVoucherFound(false);
-      setVoucherInfo({});
-    }
-
-    voucherRetrieval();
-  }, []);
+  const { loading, voucher, found } = useContext(VoucherContext);
 
   return (
     <>
-      {loadingVoucher === true ? (
+      {loading === true ? (
         <div className={styles.loader}>
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" style={{
             width: "15px",
             height: "15px",
-          }} className={styles.spinner}>
+          }} className="spinner">
             <path fillRule="evenodd"
                   d="M13.836 2.477a.75.75 0 0 1 .75.75v3.182a.75.75 0 0 1-.75.75h-3.182a.75.75 0 0 1 0-1.5h1.37l-.84-.841a4.5 4.5 0 0 0-7.08.932.75.75 0 0 1-1.3-.75 6 6 0 0 1 9.44-1.242l.842.84V3.227a.75.75 0 0 1 .75-.75Zm-.911 7.5A.75.75 0 0 1 13.199 11a6 6 0 0 1-9.44 1.241l-.84-.84v1.371a.75.75 0 0 1-1.5 0V9.591a.75.75 0 0 1 .75-.75H5.35a.75.75 0 0 1 0 1.5H3.98l.841.841a4.5 4.5 0 0 0 7.08-.932.75.75 0 0 1 1.025-.273Z"
                   clipRule="evenodd"/>
@@ -83,98 +25,78 @@ export default function VoucherBox() {
         </div>
       ) : (
         <>
-        {voucherFound === true &&
-          <div className={[styles.box, styles.mtbig].join(' ')}>
+        {found === true &&
+          <div className={styles.box}>
             <div className={styles.giftContainer}>
-                <div className={styles.relative}>
-                  <div className={styles.whiteFadeOut}></div>
-                  <div className={styles.spinLine}></div>
-                  <div className={styles.spinAnchor}>
-                    <div className={styles.spinBox}>
-                        <div className={[styles.spinItem, styles.spinItemRight].join(' ')}>
-                          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"
+              <div className="relative">
+                <div className={styles.whiteFadeOut}></div>
+                <div className={styles.spinLine}></div>
+                <div className={styles.spinAnchor}>
+                  <div className={styles.spinBox}>
+                      <div className={[styles.spinItem, styles.spinItemRight].join(' ')}>
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"
+                             className={styles.icon}>
+                          <path
+                              d="M4.464 3.162A2 2 0 0 1 6.28 2h7.44a2 2 0 0 1 1.816 1.162l1.154 2.5c.067.145.115.291.145.438A3.508 3.508 0 0 0 16 6H4c-.288 0-.568.035-.835.1.03-.147.078-.293.145-.438l1.154-2.5Z"/>
+                          <path fillRule="evenodd"
+                                d="M2 9.5a2 2 0 0 1 2-2h12a2 2 0 1 1 0 4H4a2 2 0 0 1-2-2Zm13.24 0a.75.75 0 0 1 .75-.75H16a.75.75 0 0 1 .75.75v.01a.75.75 0 0 1-.75.75h-.01a.75.75 0 0 1-.75-.75V9.5Zm-2.25-.75a.75.75 0 0 0-.75.75v.01c0 .414.336.75.75.75H13a.75.75 0 0 0 .75-.75V9.5a.75.75 0 0 0-.75-.75h-.01ZM2 15a2 2 0 0 1 2-2h12a2 2 0 1 1 0 4H4a2 2 0 0 1-2-2Zm13.24 0a.75.75 0 0 1 .75-.75H16a.75.75 0 0 1 .75.75v.01a.75.75 0 0 1-.75.75h-.01a.75.75 0 0 1-.75-.75V15Zm-2.25-.75a.75.75 0 0 0-.75.75v.01c0 .414.336.75.75.75H13a.75.75 0 0 0 .75-.75V15a.75.75 0 0 0-.75-.75h-.01Z"
+                                clipRule="evenodd"/>
+                        </svg>
+                      </div>
+                      <div className={[styles.spinItem, styles.spinItemBottom].join(' ')}>
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"
+                             className={styles.icon}>
+                          <path
+                                d="M16.555 5.412a8.028 8.028 0 0 0-3.503-2.81 14.899 14.899 0 0 1 1.663 4.472 8.547 8.547 0 0 0 1.84-1.662ZM13.326 7.825a13.43 13.43 0 0 0-2.413-5.773 8.087 8.087 0 0 0-1.826 0 13.43 13.43 0 0 0-2.413 5.773A8.473 8.473 0 0 0 10 8.5c1.18 0 2.304-.24 3.326-.675ZM6.514 9.376A9.98 9.98 0 0 0 10 10c1.226 0 2.4-.22 3.486-.624a13.54 13.54 0 0 1-.351 3.759A13.54 13.54 0 0 1 10 13.5c-1.079 0-2.128-.127-3.134-.366a13.538 13.538 0 0 1-.352-3.758ZM5.285 7.074a14.9 14.9 0 0 1 1.663-4.471 8.028 8.028 0 0 0-3.503 2.81c.529.638 1.149 1.199 1.84 1.66ZM17.334 6.798a7.973 7.973 0 0 1 .614 4.115 13.47 13.47 0 0 1-3.178 1.72 15.093 15.093 0 0 0 .174-3.939 10.043 10.043 0 0 0 2.39-1.896ZM2.666 6.798a10.042 10.042 0 0 0 2.39 1.896 15.196 15.196 0 0 0 .174 3.94 13.472 13.472 0 0 1-3.178-1.72 7.973 7.973 0 0 1 .615-4.115ZM10 15c.898 0 1.778-.079 2.633-.23a13.473 13.473 0 0 1-1.72 3.178 8.099 8.099 0 0 1-1.826 0 13.47 13.47 0 0 1-1.72-3.178c.855.151 1.735.23 2.633.23ZM14.357 14.357a14.912 14.912 0 0 1-1.305 3.04 8.027 8.027 0 0 0 4.345-4.345c-.953.542-1.971.981-3.04 1.305ZM6.948 17.397a8.027 8.027 0 0 1-4.345-4.345c.953.542 1.971.981 3.04 1.305a14.912 14.912 0 0 0 1.305 3.04Z"/>
+                        </svg>
+                      </div>
+                      <div className={[styles.spinItem, styles.spinItemLeft].join(' ')}>
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"
                                className={styles.icon}>
-                            <path
-                                d="M4.464 3.162A2 2 0 0 1 6.28 2h7.44a2 2 0 0 1 1.816 1.162l1.154 2.5c.067.145.115.291.145.438A3.508 3.508 0 0 0 16 6H4c-.288 0-.568.035-.835.1.03-.147.078-.293.145-.438l1.154-2.5Z"/>
                             <path fillRule="evenodd"
-                                  d="M2 9.5a2 2 0 0 1 2-2h12a2 2 0 1 1 0 4H4a2 2 0 0 1-2-2Zm13.24 0a.75.75 0 0 1 .75-.75H16a.75.75 0 0 1 .75.75v.01a.75.75 0 0 1-.75.75h-.01a.75.75 0 0 1-.75-.75V9.5Zm-2.25-.75a.75.75 0 0 0-.75.75v.01c0 .414.336.75.75.75H13a.75.75 0 0 0 .75-.75V9.5a.75.75 0 0 0-.75-.75h-.01ZM2 15a2 2 0 0 1 2-2h12a2 2 0 1 1 0 4H4a2 2 0 0 1-2-2Zm13.24 0a.75.75 0 0 1 .75-.75H16a.75.75 0 0 1 .75.75v.01a.75.75 0 0 1-.75.75h-.01a.75.75 0 0 1-.75-.75V15Zm-2.25-.75a.75.75 0 0 0-.75.75v.01c0 .414.336.75.75.75H13a.75.75 0 0 0 .75-.75V15a.75.75 0 0 0-.75-.75h-.01Z"
+                                  d="M3.25 3A2.25 2.25 0 0 0 1 5.25v9.5A2.25 2.25 0 0 0 3.25 17h13.5A2.25 2.25 0 0 0 19 14.75v-9.5A2.25 2.25 0 0 0 16.75 3H3.25Zm.943 8.752a.75.75 0 0 1 .055-1.06L6.128 9l-1.88-1.693a.75.75 0 1 1 1.004-1.114l2.5 2.25a.75.75 0 0 1 0 1.114l-2.5 2.25a.75.75 0 0 1-1.06-.055ZM9.75 10.25a.75.75 0 0 0 0 1.5h2.5a.75.75 0 0 0 0-1.5h-2.5Z"
                                   clipRule="evenodd"/>
-                          </svg>
-                        </div>
-                        <div className={[styles.spinItem, styles.spinItemBottom].join(' ')}>
-                          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"
-                               className={styles.icon}>
-                            <path
-                                  d="M16.555 5.412a8.028 8.028 0 0 0-3.503-2.81 14.899 14.899 0 0 1 1.663 4.472 8.547 8.547 0 0 0 1.84-1.662ZM13.326 7.825a13.43 13.43 0 0 0-2.413-5.773 8.087 8.087 0 0 0-1.826 0 13.43 13.43 0 0 0-2.413 5.773A8.473 8.473 0 0 0 10 8.5c1.18 0 2.304-.24 3.326-.675ZM6.514 9.376A9.98 9.98 0 0 0 10 10c1.226 0 2.4-.22 3.486-.624a13.54 13.54 0 0 1-.351 3.759A13.54 13.54 0 0 1 10 13.5c-1.079 0-2.128-.127-3.134-.366a13.538 13.538 0 0 1-.352-3.758ZM5.285 7.074a14.9 14.9 0 0 1 1.663-4.471 8.028 8.028 0 0 0-3.503 2.81c.529.638 1.149 1.199 1.84 1.66ZM17.334 6.798a7.973 7.973 0 0 1 .614 4.115 13.47 13.47 0 0 1-3.178 1.72 15.093 15.093 0 0 0 .174-3.939 10.043 10.043 0 0 0 2.39-1.896ZM2.666 6.798a10.042 10.042 0 0 0 2.39 1.896 15.196 15.196 0 0 0 .174 3.94 13.472 13.472 0 0 1-3.178-1.72 7.973 7.973 0 0 1 .615-4.115ZM10 15c.898 0 1.778-.079 2.633-.23a13.473 13.473 0 0 1-1.72 3.178 8.099 8.099 0 0 1-1.826 0 13.47 13.47 0 0 1-1.72-3.178c.855.151 1.735.23 2.633.23ZM14.357 14.357a14.912 14.912 0 0 1-1.305 3.04 8.027 8.027 0 0 0 4.345-4.345c-.953.542-1.971.981-3.04 1.305ZM6.948 17.397a8.027 8.027 0 0 1-4.345-4.345c.953.542 1.971.981 3.04 1.305a14.912 14.912 0 0 0 1.305 3.04Z"/>
-                          </svg>
-                        </div>
-                        <div className={[styles.spinItem, styles.spinItemLeft].join(' ')}>
-                          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"
-                                 className={styles.icon}>
-                              <path fillRule="evenodd"
-                                    d="M3.25 3A2.25 2.25 0 0 0 1 5.25v9.5A2.25 2.25 0 0 0 3.25 17h13.5A2.25 2.25 0 0 0 19 14.75v-9.5A2.25 2.25 0 0 0 16.75 3H3.25Zm.943 8.752a.75.75 0 0 1 .055-1.06L6.128 9l-1.88-1.693a.75.75 0 1 1 1.004-1.114l2.5 2.25a.75.75 0 0 1 0 1.114l-2.5 2.25a.75.75 0 0 1-1.06-.055ZM9.75 10.25a.75.75 0 0 0 0 1.5h2.5a.75.75 0 0 0 0-1.5h-2.5Z"
-                                    clipRule="evenodd"/>
-                          </svg>
-                        </div>
-                        <div className={[styles.spinItem, styles.spinItemTop].join(' ')}>
-                          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"
-                               className={styles.icon}>
-                            <path
-                                d="M1 12.5A4.5 4.5 0 0 0 5.5 17H15a4 4 0 0 0 1.866-7.539 3.504 3.504 0 0 0-4.504-4.272A4.5 4.5 0 0 0 4.06 8.235 4.502 4.502 0 0 0 1 12.5Z"/>
-                          </svg>
-                        </div>
-                    </div>
-                  </div>
-                  <div className={styles.giftPackage}>
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"
-                         className={styles.icon}>
-                        <path
-                          d="M9.375 3a1.875 1.875 0 0 0 0 3.75h1.875v4.5H3.375A1.875 1.875 0 0 1 1.5 9.375v-.75c0-1.036.84-1.875 1.875-1.875h3.193A3.375 3.375 0 0 1 12 2.753a3.375 3.375 0 0 1 5.432 3.997h3.943c1.035 0 1.875.84 1.875 1.875v.75c0 1.036-.84 1.875-1.875 1.875H12.75v-4.5h1.875a1.875 1.875 0 1 0-1.875-1.875V6.75h-1.5V4.875C11.25 3.839 10.41 3 9.375 3ZM11.25 12.75H3v6.75a2.25 2.25 0 0 0 2.25 2.25h6v-9ZM12.75 12.75v9h6.75a2.25 2.25 0 0 0 2.25-2.25v-6.75h-9Z"/>
-                    </svg>
+                        </svg>
+                      </div>
+                      <div className={[styles.spinItem, styles.spinItemTop].join(' ')}>
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"
+                             className={styles.icon}>
+                          <path
+                              d="M1 12.5A4.5 4.5 0 0 0 5.5 17H15a4 4 0 0 0 1.866-7.539 3.504 3.504 0 0 0-4.504-4.272A4.5 4.5 0 0 0 4.06 8.235 4.502 4.502 0 0 0 1 12.5Z"/>
+                        </svg>
+                      </div>
                   </div>
                 </div>
+                <div className={styles.giftPackage}>
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"
+                       className={styles.icon}>
+                      <path
+                        d="M9.375 3a1.875 1.875 0 0 0 0 3.75h1.875v4.5H3.375A1.875 1.875 0 0 1 1.5 9.375v-.75c0-1.036.84-1.875 1.875-1.875h3.193A3.375 3.375 0 0 1 12 2.753a3.375 3.375 0 0 1 5.432 3.997h3.943c1.035 0 1.875.84 1.875 1.875v.75c0 1.036-.84 1.875-1.875 1.875H12.75v-4.5h1.875a1.875 1.875 0 1 0-1.875-1.875V6.75h-1.5V4.875C11.25 3.839 10.41 3 9.375 3ZM11.25 12.75H3v6.75a2.25 2.25 0 0 0 2.25 2.25h6v-9ZM12.75 12.75v9h6.75a2.25 2.25 0 0 0 2.25-2.25v-6.75h-9Z"/>
+                  </svg>
+                </div>
+              </div>
             </div>
-              <div className={[styles.contentContainer, styles.mtsmall].join(' ')}>
+            <div className={[styles.contentContainer, styles.mtsmall].join(' ')}>
               <span className={styles.voucherValue}>
-                  {voucherInfo.value} {voucherInfo.type}
+                  {voucher.value} {voucher.type}
               </span>
               <span className={styles.voucherLabel}>
-                  <Translate>
+                  <Translate id="voucherbox.title">
                       Hosting Voucher
                   </Translate>
               </span>
-                <CopyToClipboard text={voucherInfo.code} onCopy={codeCopyFeedback}>
-                  <button type="button" className={[styles.voucherButton, styles.mtsmall].join(' ')} title={voucherInfo.code}>
-                    <span className={styles.voucherCode}>
-                      {voucherWasJustCopied === false ? (
-                        voucherInfo.code
-                      ) : (
-                        <span>
-                          <Translate>
-                            YEEEAH!
-                          </Translate>
-                        </span>
-                      )}
-                    </span>
-                    <div className={styles.copyBox}>
-                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor"
-                             className={styles.icon}>
-                            <path
-                                d="M5.5 3.5A1.5 1.5 0 0 1 7 2h2.879a1.5 1.5 0 0 1 1.06.44l2.122 2.12a1.5 1.5 0 0 1 .439 1.061V9.5A1.5 1.5 0 0 1 12 11V8.621a3 3 0 0 0-.879-2.121L9 4.379A3 3 0 0 0 6.879 3.5H5.5Z"/>
-                            <path
-                                d="M4 5a1.5 1.5 0 0 0-1.5 1.5v6A1.5 1.5 0 0 0 4 14h5a1.5 1.5 0 0 0 1.5-1.5V8.621a1.5 1.5 0 0 0-.44-1.06L7.94 5.439A1.5 1.5 0 0 0 6.878 5H4Z"/>
-                        </svg>
-                    </div>
-                  </button>
-                </CopyToClipboard>
+                <div className={styles.mtsmall}>
+                    <VoucherButton code={voucher.code}></VoucherButton>
+                </div>
                 <a className={[styles.actionLink, styles.mtbig, styles.mbmid].join(' ')} href={siteConfig.customFields.marketingSite}
                    target="_blank"
                    title={translate({
+                     id: 'voucherbox.cta',
                      message: 'Rent a server',
                    })}
                 >
                 <span className={styles.actionLabel}>
-                  <Translate>
+                  <Translate id="voucher.redeem">
                     Redeem
                   </Translate>
                 </span>

--- a/src/theme/VoucherBox/index.tsx
+++ b/src/theme/VoucherBox/index.tsx
@@ -1,0 +1,195 @@
+import { useEffect, useState } from "react";
+import styles from "./styles.module.css";
+import { CopyToClipboard } from "react-copy-to-clipboard";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+import Translate, {translate} from '@docusaurus/Translate';
+
+export default function VoucherBox() {
+  const { siteConfig } = useDocusaurusContext();
+
+  const [
+    loadingVoucher,
+    setLoadingVoucher,
+  ] = useState(false);
+
+  const [
+    voucherInfo,
+    setVoucherInfo,
+  ] = useState({});
+
+  const [
+    voucherFound,
+    setVoucherFound,
+  ] = useState(null);
+
+  const [
+    voucherWasJustCopied,
+    setVoucherWasJustCopied,
+  ] = useState(false);
+
+  function codeCopyFeedback(text, result) {
+    console.log(text, result)
+    if (result === false) {
+      return;
+    }
+
+    setVoucherWasJustCopied(true);
+
+    setTimeout(() => {
+      setVoucherWasJustCopied(false);
+    }, 1000);
+  }
+
+  useEffect(() => {
+    const voucherRetrieval = async () => {
+      setLoadingVoucher(true);
+
+      const voucherResponse = await (
+        await fetch("https://zap-hosting.com/interface/shop/_ajax/json_getDocsCoupon.php", {
+          headers: {
+            "X-Requested-With": "XMLHttpRequest",
+          },
+        }).finally(() => {
+          setLoadingVoucher(false);
+        })
+      ).json();
+
+      if (voucherResponse.message === "ok" && voucherResponse.result === "success") {
+        setVoucherFound(true);
+        setVoucherInfo(voucherResponse.data);
+
+        return;
+      }
+
+      setVoucherFound(false);
+      setVoucherInfo({});
+    }
+
+    voucherRetrieval();
+  }, []);
+
+  return (
+    <>
+      {loadingVoucher === true ? (
+        <div className={styles.loader}>
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" style={{
+            width: "15px",
+            height: "15px",
+          }} className={styles.spinner}>
+            <path fillRule="evenodd"
+                  d="M13.836 2.477a.75.75 0 0 1 .75.75v3.182a.75.75 0 0 1-.75.75h-3.182a.75.75 0 0 1 0-1.5h1.37l-.84-.841a4.5 4.5 0 0 0-7.08.932.75.75 0 0 1-1.3-.75 6 6 0 0 1 9.44-1.242l.842.84V3.227a.75.75 0 0 1 .75-.75Zm-.911 7.5A.75.75 0 0 1 13.199 11a6 6 0 0 1-9.44 1.241l-.84-.84v1.371a.75.75 0 0 1-1.5 0V9.591a.75.75 0 0 1 .75-.75H5.35a.75.75 0 0 1 0 1.5H3.98l.841.841a4.5 4.5 0 0 0 7.08-.932.75.75 0 0 1 1.025-.273Z"
+                  clipRule="evenodd"/>
+          </svg>
+        </div>
+      ) : (
+        <>
+        {voucherFound === true &&
+          <div className={[styles.box, styles.mtbig].join(' ')}>
+            <div className={styles.giftContainer}>
+                <div className={styles.relative}>
+                  <div className={styles.whiteFadeOut}></div>
+                  <div className={styles.spinLine}></div>
+                  <div className={styles.spinAnchor}>
+                    <div className={styles.spinBox}>
+                        <div className={[styles.spinItem, styles.spinItemRight].join(' ')}>
+                          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"
+                               className={styles.icon}>
+                            <path
+                                d="M4.464 3.162A2 2 0 0 1 6.28 2h7.44a2 2 0 0 1 1.816 1.162l1.154 2.5c.067.145.115.291.145.438A3.508 3.508 0 0 0 16 6H4c-.288 0-.568.035-.835.1.03-.147.078-.293.145-.438l1.154-2.5Z"/>
+                            <path fillRule="evenodd"
+                                  d="M2 9.5a2 2 0 0 1 2-2h12a2 2 0 1 1 0 4H4a2 2 0 0 1-2-2Zm13.24 0a.75.75 0 0 1 .75-.75H16a.75.75 0 0 1 .75.75v.01a.75.75 0 0 1-.75.75h-.01a.75.75 0 0 1-.75-.75V9.5Zm-2.25-.75a.75.75 0 0 0-.75.75v.01c0 .414.336.75.75.75H13a.75.75 0 0 0 .75-.75V9.5a.75.75 0 0 0-.75-.75h-.01ZM2 15a2 2 0 0 1 2-2h12a2 2 0 1 1 0 4H4a2 2 0 0 1-2-2Zm13.24 0a.75.75 0 0 1 .75-.75H16a.75.75 0 0 1 .75.75v.01a.75.75 0 0 1-.75.75h-.01a.75.75 0 0 1-.75-.75V15Zm-2.25-.75a.75.75 0 0 0-.75.75v.01c0 .414.336.75.75.75H13a.75.75 0 0 0 .75-.75V15a.75.75 0 0 0-.75-.75h-.01Z"
+                                  clipRule="evenodd"/>
+                          </svg>
+                        </div>
+                        <div className={[styles.spinItem, styles.spinItemBottom].join(' ')}>
+                          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"
+                               className={styles.icon}>
+                            <path
+                                  d="M16.555 5.412a8.028 8.028 0 0 0-3.503-2.81 14.899 14.899 0 0 1 1.663 4.472 8.547 8.547 0 0 0 1.84-1.662ZM13.326 7.825a13.43 13.43 0 0 0-2.413-5.773 8.087 8.087 0 0 0-1.826 0 13.43 13.43 0 0 0-2.413 5.773A8.473 8.473 0 0 0 10 8.5c1.18 0 2.304-.24 3.326-.675ZM6.514 9.376A9.98 9.98 0 0 0 10 10c1.226 0 2.4-.22 3.486-.624a13.54 13.54 0 0 1-.351 3.759A13.54 13.54 0 0 1 10 13.5c-1.079 0-2.128-.127-3.134-.366a13.538 13.538 0 0 1-.352-3.758ZM5.285 7.074a14.9 14.9 0 0 1 1.663-4.471 8.028 8.028 0 0 0-3.503 2.81c.529.638 1.149 1.199 1.84 1.66ZM17.334 6.798a7.973 7.973 0 0 1 .614 4.115 13.47 13.47 0 0 1-3.178 1.72 15.093 15.093 0 0 0 .174-3.939 10.043 10.043 0 0 0 2.39-1.896ZM2.666 6.798a10.042 10.042 0 0 0 2.39 1.896 15.196 15.196 0 0 0 .174 3.94 13.472 13.472 0 0 1-3.178-1.72 7.973 7.973 0 0 1 .615-4.115ZM10 15c.898 0 1.778-.079 2.633-.23a13.473 13.473 0 0 1-1.72 3.178 8.099 8.099 0 0 1-1.826 0 13.47 13.47 0 0 1-1.72-3.178c.855.151 1.735.23 2.633.23ZM14.357 14.357a14.912 14.912 0 0 1-1.305 3.04 8.027 8.027 0 0 0 4.345-4.345c-.953.542-1.971.981-3.04 1.305ZM6.948 17.397a8.027 8.027 0 0 1-4.345-4.345c.953.542 1.971.981 3.04 1.305a14.912 14.912 0 0 0 1.305 3.04Z"/>
+                          </svg>
+                        </div>
+                        <div className={[styles.spinItem, styles.spinItemLeft].join(' ')}>
+                          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"
+                                 className={styles.icon}>
+                              <path fillRule="evenodd"
+                                    d="M3.25 3A2.25 2.25 0 0 0 1 5.25v9.5A2.25 2.25 0 0 0 3.25 17h13.5A2.25 2.25 0 0 0 19 14.75v-9.5A2.25 2.25 0 0 0 16.75 3H3.25Zm.943 8.752a.75.75 0 0 1 .055-1.06L6.128 9l-1.88-1.693a.75.75 0 1 1 1.004-1.114l2.5 2.25a.75.75 0 0 1 0 1.114l-2.5 2.25a.75.75 0 0 1-1.06-.055ZM9.75 10.25a.75.75 0 0 0 0 1.5h2.5a.75.75 0 0 0 0-1.5h-2.5Z"
+                                    clipRule="evenodd"/>
+                          </svg>
+                        </div>
+                        <div className={[styles.spinItem, styles.spinItemTop].join(' ')}>
+                          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"
+                               className={styles.icon}>
+                            <path
+                                d="M1 12.5A4.5 4.5 0 0 0 5.5 17H15a4 4 0 0 0 1.866-7.539 3.504 3.504 0 0 0-4.504-4.272A4.5 4.5 0 0 0 4.06 8.235 4.502 4.502 0 0 0 1 12.5Z"/>
+                          </svg>
+                        </div>
+                    </div>
+                  </div>
+                  <div className={styles.giftPackage}>
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"
+                         className={styles.icon}>
+                        <path
+                          d="M9.375 3a1.875 1.875 0 0 0 0 3.75h1.875v4.5H3.375A1.875 1.875 0 0 1 1.5 9.375v-.75c0-1.036.84-1.875 1.875-1.875h3.193A3.375 3.375 0 0 1 12 2.753a3.375 3.375 0 0 1 5.432 3.997h3.943c1.035 0 1.875.84 1.875 1.875v.75c0 1.036-.84 1.875-1.875 1.875H12.75v-4.5h1.875a1.875 1.875 0 1 0-1.875-1.875V6.75h-1.5V4.875C11.25 3.839 10.41 3 9.375 3ZM11.25 12.75H3v6.75a2.25 2.25 0 0 0 2.25 2.25h6v-9ZM12.75 12.75v9h6.75a2.25 2.25 0 0 0 2.25-2.25v-6.75h-9Z"/>
+                    </svg>
+                  </div>
+                </div>
+            </div>
+              <div className={[styles.contentContainer, styles.mtsmall].join(' ')}>
+              <span className={styles.voucherValue}>
+                  {voucherInfo.value} {voucherInfo.type}
+              </span>
+              <span className={styles.voucherLabel}>
+                  <Translate>
+                      Hosting Voucher
+                  </Translate>
+              </span>
+                <CopyToClipboard text={voucherInfo.code} onCopy={codeCopyFeedback}>
+                  <button type="button" className={[styles.voucherButton, styles.mtsmall].join(' ')} title={voucherInfo.code}>
+                    <span className={styles.voucherCode}>
+                      {voucherWasJustCopied === false ? (
+                        voucherInfo.code
+                      ) : (
+                        <span>
+                          <Translate>
+                            YEEEAH!
+                          </Translate>
+                        </span>
+                      )}
+                    </span>
+                    <div className={styles.copyBox}>
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor"
+                             className={styles.icon}>
+                            <path
+                                d="M5.5 3.5A1.5 1.5 0 0 1 7 2h2.879a1.5 1.5 0 0 1 1.06.44l2.122 2.12a1.5 1.5 0 0 1 .439 1.061V9.5A1.5 1.5 0 0 1 12 11V8.621a3 3 0 0 0-.879-2.121L9 4.379A3 3 0 0 0 6.879 3.5H5.5Z"/>
+                            <path
+                                d="M4 5a1.5 1.5 0 0 0-1.5 1.5v6A1.5 1.5 0 0 0 4 14h5a1.5 1.5 0 0 0 1.5-1.5V8.621a1.5 1.5 0 0 0-.44-1.06L7.94 5.439A1.5 1.5 0 0 0 6.878 5H4Z"/>
+                        </svg>
+                    </div>
+                  </button>
+                </CopyToClipboard>
+                <a className={[styles.actionLink, styles.mtbig, styles.mbmid].join(' ')} href={siteConfig.customFields.marketingSite}
+                   target="_blank"
+                   title={translate({
+                     message: 'Rent a server',
+                   })}
+                >
+                <span className={styles.actionLabel}>
+                  <Translate>
+                    Redeem
+                  </Translate>
+                </span>
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor"
+                         className={styles.icon}>
+                        <path fillRule="evenodd"
+                              d="M6.22 4.22a.75.75 0 0 1 1.06 0l3.25 3.25a.75.75 0 0 1 0 1.06l-3.25 3.25a.75.75 0 0 1-1.06-1.06L8.94 8 6.22 5.28a.75.75 0 0 1 0-1.06Z"
+                              clipRule="evenodd"/>
+                    </svg>
+                </a>
+            </div>
+          </div>
+        }
+        </>
+      )}
+    </>
+  );
+}

--- a/src/theme/VoucherBox/styles.module.css
+++ b/src/theme/VoucherBox/styles.module.css
@@ -16,6 +16,11 @@
     }
 }
 
+[data-theme='dark'] .box {
+    background-color: rgb(38 38 38);
+    border: none;
+}
+
 .box {
     position: relative;
     display: flex;
@@ -23,9 +28,9 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
+    overflow: hidden;
     border-radius: .5em;
-    border-width: 1px;
-    border-color: #F4F4F5;
+    border: 1px solid rgb(228 228 231 / .6);
     background-color: white;
     text-align: center;
     box-shadow: 0 1px 3px 0 rgb(0 0 0 / .1), 0 1px 2px -1px rgb(0 0 0 / .1);
@@ -42,12 +47,20 @@
 
 .giftContainer .whiteFadeOut {
     position: absolute;
-    bottom: -1.75rem;
+    bottom: -1.25rem;
     top: -1.75rem;
     left: -100%;
     right: -100%;
     z-index: 10;
-    background-image: linear-gradient(to bottom, rgba(255, 255, 255, 100) 0%, rgba(0, 0, 0, 0) 50%, rgba(255, 255, 255, 100));
+    background-image: linear-gradient(to bottom, rgba(255, 255, 255, .75) 0%, rgba(0, 0, 0, 0) 50%, rgba(255, 255, 255, 100));
+}
+
+[data-theme='dark'] .giftContainer .whiteFadeOut {
+    background-image: linear-gradient(to bottom, rgb(38 38 38) 0%, rgba(0, 0, 0, 0) 50%, rgb(38 38 38));
+}
+
+[data-theme='dark'] .giftContainer .spinLine {
+    border-color: rgb(132 204 22 / .1);
 }
 
 .giftContainer .spinLine {
@@ -72,6 +85,10 @@
     inset: 0;
     opacity: .75;
     animation: spin 10000ms linear infinite;
+}
+
+[data-theme='dark'] .giftContainer .spinAnchor > .spinBox > .spinItem {
+    background-color: rgb(54 83 20 / .25);
 }
 
 .giftContainer .spinAnchor > .spinBox > .spinItem {
@@ -106,6 +123,10 @@
     animation: spin-reverse 10000ms linear infinite;
 }
 
+[data-theme='dark'] .giftContainer .giftPackage {
+    background-color: rgb(54 83 20 / .2);
+}
+
 .giftContainer .giftPackage {
     position: relative;
     z-index: 20;
@@ -116,6 +137,10 @@
     justify-content: center;
     border-radius: 9999px;
     background-color: #F7FEE7;
+}
+
+[data-theme='dark'] .giftContainer .giftPackage > .icon {
+    color: rgb(217 249 157);
 }
 
 .giftContainer .giftPackage > .icon {
@@ -133,11 +158,19 @@
     padding: 0 1.5rem;
 }
 
+[data-theme='dark'] .contentContainer .voucherValue {
+    color: rgb(247 254 231);
+}
+
 .contentContainer .voucherValue {
     font-size: 1.125rem;
     line-height: 1.75rem;
     font-weight: 600;
     color: #27272A;
+}
+
+[data-theme='dark'] .contentContainer .voucherLabel {
+    color: rgb(236 252 203);
 }
 
 .contentContainer .voucherLabel {
@@ -146,72 +179,15 @@
     color: #3F3F46;
 }
 
-.contentContainer .voucherButton {
-    display: flex;
-    cursor: pointer;
-    align-items: center;
-    justify-content: center;
-    border-width: 1px;
-    border-color: rgb(132 204 22 / .15);
-    background-color: #ECFCCB;
-    padding: .25rem .25rem .25rem .75rem;
-    font-size: 0.75rem;
-    line-height: 1rem;
-    font-weight: 700;
-    box-shadow: 0 10px 15px -3px rgb(132 204 22 / .15), 0 4px 6px -4px rgb(132 204 22 / .15);
-    border-radius: 9999px;
-    transition-property: all;
-    transition-timing-function: cubic-bezier(0.4, 0, .2, 1);
-    transition-duration: 700ms;
-}
-
-.contentContainer .voucherButton:hover {
-    transform: scaleX(1.05) scaleY(1.05);
-    box-shadow: 0 20px 25px -5px rgb(132 204 22 / .2), 0 8px 10px -6px rgb(132 204 22 / .2);
-}
-
-.contentContainer .voucherButton:active {
-    transition-duration: 150ms;
-    transform: scaleX(.95) scaleY(.95);
-}
-
-.contentContainer .voucherButton .voucherCode {
-    padding-right: .5rem;
-    color: #3F6212;
-    max-width: 5rem;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-}
-
-.contentContainer .voucherButton .copyBox {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: 9999px;
-    border: 1px solid rgb(77 124 15 / .15);
-    background-color: #F7FEE7;
-    padding: .25rem;
-}
-
-.contentContainer .voucherButton .copyBox .icon {
-    width: .75rem;
-    height: .75rem;
-    color: #84cc16;
-    transition-property: all;
-    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-    transition-duration: 700ms;
-}
-
-.contentContainer .voucherButton:hover .copyBox .icon {
-    color: #4D7C0F;
-}
-
 .contentContainer .actionLink {
     display: flex;
     align-items: center;
     text-decoration: none;
     cursor: pointer;
+}
+
+[data-theme='dark'] .contentContainer .actionLink .actionLabel {
+    color: rgb(115 115 115);
 }
 
 .contentContainer .actionLink .actionLabel {
@@ -224,8 +200,16 @@
     transition-duration: 700ms;
 }
 
+[data-theme='dark'] .contentContainer .actionLink:hover .actionLabel {
+    color: rgb(244 244 245);
+}
+
 .contentContainer .actionLink:hover .actionLabel {
     color: #27272A;
+}
+
+[data-theme='dark'] .contentContainer .actionLink .icon {
+    color: rgb(82 82 82);
 }
 
 .contentContainer .actionLink .icon {
@@ -237,13 +221,13 @@
     transition-duration: 300ms;
 }
 
+[data-theme='dark'] .contentContainer .actionLink:hover .icon {
+    color: rgb(212 212 216);
+}
+
 .contentContainer .actionLink:hover .icon {
     color: #52525B;
     transform: translate(.125rem);
-}
-
-.relative {
-    position: relative;
 }
 
 .mtsmall {
@@ -264,8 +248,4 @@
     padding: 20px;
     align-items: center;
     justify-content: center;
-}
-
-.spinner {
-    animation: spin 1s linear infinite;
 }

--- a/src/theme/VoucherBox/styles.module.css
+++ b/src/theme/VoucherBox/styles.module.css
@@ -1,0 +1,271 @@
+@keyframes spin {
+    from {
+        transform: rotate(0deg);
+    }
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+@keyframes spin-reverse {
+    from {
+        transform: rotate(0deg);
+    }
+    to {
+        transform: rotate(-360deg);
+    }
+}
+
+.box {
+    position: relative;
+    display: flex;
+    max-width: 13rem;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    border-radius: .5em;
+    border-width: 1px;
+    border-color: #F4F4F5;
+    background-color: white;
+    text-align: center;
+    box-shadow: 0 1px 3px 0 rgb(0 0 0 / .1), 0 1px 2px -1px rgb(0 0 0 / .1);
+}
+
+.giftContainer {
+    display: flex;
+    width: 100%;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    padding: 1.25rem 0;
+}
+
+.giftContainer .whiteFadeOut {
+    position: absolute;
+    bottom: -1.75rem;
+    top: -1.75rem;
+    left: -100%;
+    right: -100%;
+    z-index: 10;
+    background-image: linear-gradient(to bottom, rgba(255, 255, 255, 100) 0%, rgba(0, 0, 0, 0) 50%, rgba(255, 255, 255, 100));
+}
+
+.giftContainer .spinLine {
+    position: absolute;
+    inset: -1.5rem;
+    border-radius: 9999px;
+    border: 1px solid rgb(132 204 22 / .2);
+}
+
+.giftContainer .spinAnchor {
+    position: absolute;
+    inset: 0;
+    left: 50%;
+    top: 50%;
+    display: flex;
+    z-index: 0;
+    transform: translate(-50%, -50%);
+}
+
+.giftContainer .spinAnchor > .spinBox {
+    position: absolute;
+    inset: 0;
+    opacity: .75;
+    animation: spin 10000ms linear infinite;
+}
+
+.giftContainer .spinAnchor > .spinBox > .spinItem {
+    position: absolute;
+    height: 2rem;
+    width: 2rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid rgb(77 124 15 / 0.1);
+    border-radius: 9999px;
+    background-color: white;
+}
+
+.giftContainer .spinAnchor > .spinBox > .spinItem.spinItemRight {
+    transform: translate(3.5rem);
+}
+.giftContainer .spinAnchor > .spinBox > .spinItem.spinItemLeft {
+    transform: translate(-3.5rem);
+}
+.giftContainer .spinAnchor > .spinBox > .spinItem.spinItemBottom {
+    transform: translate(0, 3.5rem);
+}
+.giftContainer .spinAnchor > .spinBox > .spinItem.spinItemTop {
+    transform: translate(0, -3.5rem);
+}
+
+.giftContainer .spinAnchor > .spinBox > .spinItem > .icon {
+    width: 1rem;
+    height: 1rem;
+    color: #BEF264;
+    animation: spin-reverse 10000ms linear infinite;
+}
+
+.giftContainer .giftPackage {
+    position: relative;
+    z-index: 20;
+    display: flex;
+    width: 4rem;
+    height: 4rem;
+    align-items: center;
+    justify-content: center;
+    border-radius: 9999px;
+    background-color: #F7FEE7;
+}
+
+.giftContainer .giftPackage > .icon {
+    width: 1.5rem;
+    height: 1.5rem;
+    color: #4D7C0F;
+}
+
+.contentContainer {
+    position: relative;
+    z-index: 10;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 0 1.5rem;
+}
+
+.contentContainer .voucherValue {
+    font-size: 1.125rem;
+    line-height: 1.75rem;
+    font-weight: 600;
+    color: #27272A;
+}
+
+.contentContainer .voucherLabel {
+    font-size: 0.875rem;
+    line-height: 1.25rem;
+    color: #3F3F46;
+}
+
+.contentContainer .voucherButton {
+    display: flex;
+    cursor: pointer;
+    align-items: center;
+    justify-content: center;
+    border-width: 1px;
+    border-color: rgb(132 204 22 / .15);
+    background-color: #ECFCCB;
+    padding: .25rem .25rem .25rem .75rem;
+    font-size: 0.75rem;
+    line-height: 1rem;
+    font-weight: 700;
+    box-shadow: 0 10px 15px -3px rgb(132 204 22 / .15), 0 4px 6px -4px rgb(132 204 22 / .15);
+    border-radius: 9999px;
+    transition-property: all;
+    transition-timing-function: cubic-bezier(0.4, 0, .2, 1);
+    transition-duration: 700ms;
+}
+
+.contentContainer .voucherButton:hover {
+    transform: scaleX(1.05) scaleY(1.05);
+    box-shadow: 0 20px 25px -5px rgb(132 204 22 / .2), 0 8px 10px -6px rgb(132 204 22 / .2);
+}
+
+.contentContainer .voucherButton:active {
+    transition-duration: 150ms;
+    transform: scaleX(.95) scaleY(.95);
+}
+
+.contentContainer .voucherButton .voucherCode {
+    padding-right: .5rem;
+    color: #3F6212;
+    max-width: 5rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.contentContainer .voucherButton .copyBox {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 9999px;
+    border: 1px solid rgb(77 124 15 / .15);
+    background-color: #F7FEE7;
+    padding: .25rem;
+}
+
+.contentContainer .voucherButton .copyBox .icon {
+    width: .75rem;
+    height: .75rem;
+    color: #84cc16;
+    transition-property: all;
+    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+    transition-duration: 700ms;
+}
+
+.contentContainer .voucherButton:hover .copyBox .icon {
+    color: #4D7C0F;
+}
+
+.contentContainer .actionLink {
+    display: flex;
+    align-items: center;
+    text-decoration: none;
+    cursor: pointer;
+}
+
+.contentContainer .actionLink .actionLabel {
+    padding-right: 0.25rem;
+    font-size: 0.75rem;
+    line-height: 1rem;
+    color: #71717A;
+    transition-property: all;
+    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+    transition-duration: 700ms;
+}
+
+.contentContainer .actionLink:hover .actionLabel {
+    color: #27272A;
+}
+
+.contentContainer .actionLink .icon {
+    width: .75rem;
+    height: .75rem;
+    color: #A1A1AA;
+    transition-property: all;
+    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+    transition-duration: 300ms;
+}
+
+.contentContainer .actionLink:hover .icon {
+    color: #52525B;
+    transform: translate(.125rem);
+}
+
+.relative {
+    position: relative;
+}
+
+.mtsmall {
+    margin-top: 1rem;
+}
+
+.mtbig {
+    margin-top: 2rem;
+}
+
+.mbmid {
+    margin-bottom: 1.5rem;
+}
+
+.loader {
+    display: flex;
+    width: 100%;
+    padding: 20px;
+    align-items: center;
+    justify-content: center;
+}
+
+.spinner {
+    animation: spin 1s linear infinite;
+}

--- a/src/utilities/contexts/VoucherContext.js
+++ b/src/utilities/contexts/VoucherContext.js
@@ -1,0 +1,62 @@
+import { createContext, useEffect, useState } from 'react';
+
+export const VoucherContext = createContext({
+    loading: false,
+    found: false,
+    voucher: null,
+});
+
+export const VoucherProvider = props => {
+    const [
+        loading,
+        setLoading,
+    ] = useState(false);
+
+    const [
+        voucher,
+        setVoucher,
+    ] = useState({});
+
+    const [
+        found,
+        setFound,
+    ] = useState(null);
+
+    useEffect(() => {
+        const voucherRetrieval = async () => {
+            setLoading(true);
+
+            const voucherResponse = await (
+                await fetch('https://zap-hosting.com/interface/shop/_ajax/json_getDocsCoupon.php', {
+                    headers: {
+                        'X-Requested-With': 'XMLHttpRequest',
+                    },
+                }).finally(() => {
+                    setLoading(false);
+                })
+            ).json();
+
+            if (voucherResponse.message === 'ok' && voucherResponse.result === 'success') {
+                setFound(true);
+                setVoucher(voucherResponse.data);
+
+                return;
+            }
+
+            setFound(false);
+            setVoucher({});
+        }
+
+        voucherRetrieval();
+    }, []);
+
+    return (
+        <VoucherContext.Provider value={{
+            loading: loading,
+            found: found,
+            voucher: voucher,
+        }}>
+            { props.children }
+        </VoucherContext.Provider>
+    )
+}

--- a/src/utilities/serviceMapper.tsx
+++ b/src/utilities/serviceMapper.tsx
@@ -1,0 +1,28 @@
+import servicesMap, { serviceDetails } from './services.map';
+import { interpolate } from '@docusaurus/Interpolate';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+
+export default function map(key: string): serviceDetails {
+  const { siteConfig, i18n } = useDocusaurusContext();
+
+  if (servicesMap.hasOwnProperty(key) === false) {
+    return null;
+  }
+
+  const info = servicesMap[key];
+
+  info.url = interpolate(info.url, {
+    marketingSite: siteConfig.customFields.marketingSite,
+    language: i18n.currentLocale,
+  });
+
+  return info;
+}
+
+export function mapList(keys: Array<string>): serviceDetails[] {
+  let serviceInfoList = new Array<serviceDetails>;
+
+  keys.forEach(key => serviceInfoList.push(map(key)));
+
+  return serviceInfoList.filter((serviceInfo) => serviceInfo !== null);
+}

--- a/src/utilities/services.map.tsx
+++ b/src/utilities/services.map.tsx
@@ -1,0 +1,39 @@
+import { translate } from '@docusaurus/Translate';
+
+interface serviceMap {
+    [key: string]: serviceDetails,
+}
+
+export interface serviceDetails {
+    [title: string]: string,
+    [path: string]: string,
+}
+
+const servicesMap: serviceMap = {
+    'gameserver': {
+        title: translate({
+            message: 'Cloud-Gameserver',
+            id: 'service.gameserver.title',
+            description: 'Product name for the gameserver product',
+        }),
+        url: translate({
+            message: '{marketingSite}/{language}/gameserver-hosting/',
+            id: 'service.gameserver.path',
+            description: 'URL path for the gameserver product',
+        }),
+    },
+    'premium-storage': {
+        title: translate({
+            message: 'Premium Storage',
+            id: 'service.storage.title',
+            description: 'Product name for the storage product',
+        }),
+        url: translate({
+            message: '{marketingSite}/{language}/shop/product/premium-storage/',
+            id: 'service.storage.path',
+            description: 'URL path for the storage product',
+        }),
+    },
+};
+
+export default servicesMap;


### PR DESCRIPTION
As noted [here](https://github.com/zaphosting/docs/pull/1248#issuecomment-2131360292), I extended my previous PR https://github.com/zaphosting/docs/pull/1248 to create this bigger PR.

What it roughly does (if I didn't forget something):

- Let's us link guides to specific products that are used in them.
- Displays used products with a link to them at the top of the guide.
- Loads a docs coupon from the main application and displays it in the sidebar.
- Adds a custom element to be integrated into the docs content to advertise the voucher additionally (or at all for mobile devices since the sidebar coupon is only for desktop devices).
- Improves the custom YouTube element. In it's current version, the video shrinks in the flexbox. If there is not enough space at certain viewport sizes, the video is a very thin line, horizontally speaking. The video part now has a fixed width with shrinking disabled and the content takes up the rest of the element automatically (`flex: 1 1 0%`). I also made the drop shadow a little more visually appealing (in my mind) and make it the same as my new elements. I've also slightly increased the line-height of the text.
- As discussed before, shrinks the sidebar to `300px` while reducing the font size.
- Removes a bigger breakpoint for the content container. This practically makes the main content and the sidebar on the right less wide. As a result, the text doesn't spread across 75% of the screen, which makes it more exhausting to read on bigger screens since you have to correctly move your eyes from one side of the screen to the other side while staying in the correct line you were reading. This is also why newspapers have columns. I think this is pretty simple yet effective for improving the experience.
- Adds a little more space between the content and the sidebar on the right.
- Adds a bit more space between categories in the sidebar on the left. In it's current state, it is hard to scan the sidebar to find different categories. With just a bit more space above/below the different categories, it is much easier to differentiate between them at first glance.
- Replaces a few icons with more modern looking ones (for instance the dropdown icon in the navigation, which is currently a literal triangle).
- Removes justification from the content text. It just adds quite a bit of spacing in some lines (which looks weird) to justify the text while I personally don't see any benefit in the text being a block. I think this is quite unusual.

Noteworthy explanations for usage:

## Linking products to guides

This works by using meta data (or how Docusaurus appears to be calling it: front matter) to the specific doc files in a `services` key. The services can be configured in `src/utilities/services.map.tsx`. The key must match the entry in the `services` key of the doc file. I added premium storage and cloud gameserver to the gameserver backups doc as an example.
They have a translatable title and url for displaying them with a link in the docs. The URL supports interpolation so the current language and a variable from the main config (`marketingSite`, which should hold the URL of our site advertising and describing the products, so just `zap-hosting.com` aswell for now - helps us to change the URL easily in case needed) can be used in the URLs. With this, some URLs practically do not need to be translated because for example `'{marketingSite}/{language}/shop/product/premium-storage/'`will work for both languages. It still allows us to set any link for a specific product or language though.

## Voucher loading architecture

Since the voucher is loaded in multiple elements on the site and I wanted it to be only loaded one single time (and not being loaded another time when switching between doc pages), I used a React context at the root level of the site, which is what Docusaurus recommends: https://docusaurus.io/docs/swizzling#wrapper-your-site-with-root

As I mentioned in the previous PR, I'm still not a React dev by any means though.

## Voucher element in the content

Just like the YouTube element for example, this can be added in the content (after a few headings would be the best place I'd think). I also added this as an example in the gameserver backups docs.
By default, it also displays the products from the doc page and labels them with something like "ready with all the products used in the guide:" followed by the products. Since not all products can be used with our vouchers (external products like FiveM upvotes), you can add the `showProducts` flag and set it to false:

`<InlineVoucher showProducts={false} />`

It will then display alternate content naming a few reasons why the user should give ZAP-Hosting a try. It does the same if no product is linked to the current doc page.
You can find out what products can be used with the voucher in the backend, the code is currently `docs-50`. It should have the usual configuration for these types of vouchers, just like the exit intent vouchers for example.