### PR TITLE
Dedicated Game Servers

### DIFF
--- a/docs/dedicated-linux-arksurvivalascended.md
+++ b/docs/dedicated-linux-arksurvivalascended.md
@@ -72,4 +72,6 @@ You should now see logs appear in your command prompt which signals that the sta
 
 ## Conclusion
 
-Congratulations, you have successfully installed and configurated the ARK: Survival Ascended server on your Dedicated Server! If you have any further questions or problems, please contact our support team, who are available to help you every day! 
+Congratulations, you have successfully installed and configurated the ARK: Survival Ascended server on your Dedicated Server! As a next step, we recommend looking over our [Setup Linux Service](dedicated-linux-create-gameservice.md) guide, which covers setting up your new dedicated game server as a service. This provides various benefits including automatic server launching on boot, automatic server updates, easy management and access to logs, plus much more!
+
+If you have any further questions or problems, please contact our support team, who are available to help you every day!

--- a/docs/dedicated-linux-arksurvivalascended.md
+++ b/docs/dedicated-linux-arksurvivalascended.md
@@ -30,42 +30,6 @@ ARK: Survival Ascended currently does not offer a native Linux-based server buil
 You have to complete a one-time installation of the **Wine** compatibility layer if this is your first time using this on your Linux server. Please use our quick [Wine Compatibility Layer Setup](dedicated-linux-wine.md) guide to set this up before proceeding.
 :::
 
-### Installing Wine
-
-Currently, ARK: Survival Ascended does not have a native Linux-based server build, which means that there is an extra preparation step necessary to run the Windows server build on Linux. To resolve this, you will have to install the latest version of Wine which is a compatibility layer to allow Windows-native apps to run on Linux.
-
-Firstly, ensure that the `/etc/apt/keyrings/` directory exists, as this is necessary for Wine.
-```
-sudo mkdir -pm755 /etc/apt/keyrings
-```
-
-The next step is to download and store the Wine GPG key into this directory which verifies that the package is authentic.
-```
-sudo wget -O /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key
-```
-
-You will also have to save the sources list for WineHQ which can be done with the following pre-written source file:
-```
-sudo wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/dists/$(lsb_release -cs)/winehq-$(lsb_release -cs).sources
-```
-
-Run the update command again to ensure that your package changes are read and installed.
-```
-sudo apt update
-```
-
-Now you can download the latest version of Wine.
-```
-sudo apt install --install-recommends winehq-staging
-```
-
-Finally, you need to install a few extra packages to ensure Wine works well with the ARK: Survival Ascended server by running the following command.
-```
-sudo apt install cabextract winbind screen xvfb
-```
-
-You have successfully installed the Wine comaptibility layer, which will allow you to run ARK: Survival Ascended's Windows server build on your Linux server. Proceed with the installation.
-
 ## Installation
 
 Begin by logging in to your `steam` user and heading over to the root `home/steam` user directory to keep things organised.

--- a/docs/dedicated-linux-arksurvivalascended.md
+++ b/docs/dedicated-linux-arksurvivalascended.md
@@ -1,33 +1,33 @@
 ---
-id: vserver-linux-arksurvivalascended
-title: "VPS: ARK Survival Ascended Dedicated Server Linux Setup"
-description: Information about setting up an ARK Survival Ascended Dedicated Server on a Linux VPS from ZAP-Hosting - ZAP-Hosting.com documentation
+id: dedicated-linux-arksurvivalascended
+title: "Dedicated Server: ARK Survival Ascended Dedicated Server Linux Setup"
+description: Information about setting up an ARK Survival Ascended Dedicated Server on a Linux Dedicated Server from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: ARK Survival Ascended
 services:
-  - vserver
+  - dedicated
 ---
 
 import InlineVoucher from '@site/src/components/InlineVoucher';
 
 ## Introduction
-Do you have a Linux VPS or root server and you want to install the ARK: Survival Ascended Dedicated server service on it? You are in the right place. In this guide, we will explain the step by step process of installing this service on your Linux server through the use of SteamCMD. We will be using Ubuntu in the examples, but the process should be very similar for other distributions.
+Do you have a Linux Dedicated Server and you want to install the ARK: Survival Ascended Dedicated server service on it? You are in the right place. In this guide, we will explain the step by step process of installing this service on your Linux server through the use of SteamCMD. We will be using Ubuntu in the examples, but the process should be very similar for other distributions.
 
 :::tip
-Did you know that you can install our **ZAP GS/TS3 Interface** directly onto your VPS or root server, allowing you to setup game server services, with direct integration to your ZAP-Hosting dashboard, in just a few clicks! Learn more about the [GS/TS3 Interface here](vserver-linux-gs-interface.md).
+Did you know that you can install our **ZAP GS/TS3 Interface** directly onto your dedicated server, allowing you to setup game server services, with direct integration to your ZAP-Hosting dashboard, in just a few clicks! Learn more about the [GS/TS3 Interface here](dedicated-linux-gs-interface.md).
 :::
 
 <InlineVoucher />
 
 ## Preparation
 
-To begin with, connect to your VPS or root server via SSH. Use our [SSH Initial Access](vserver-linux-ssh.md) guide if you need help doing this.
+To begin with, connect to your Dedicated Server via SSH. Use our [SSH Initial Access](vserver-linux-ssh.md) guide if you need help doing this.
 
-You will also have to complete a first-time setup for SteamCMD if this is your first time using this on your Linux server. Please use our [SteamCMD Linux Setup](vserver-linux-steamcmd.md) guide and ensure SteamCMD is fully setup before proceeding.
+You will also have to complete a first-time setup for SteamCMD if this is your first time using this on your Linux server. Please use our [SteamCMD Linux Setup](dedicated-linux-steamcmd.md) guide and ensure SteamCMD is fully setup before proceeding.
 
 :::info Wine Compatibility Layer
 ARK: Survival Ascended currently does not offer a native Linux-based server build, which means that there is an extra preparation step necessary to run the Windows server build on Linux.
 
-You have to complete a one-time installation of the **Wine** compatibility layer if this is your first time using this on your Linux server. Please use our quick [Wine Compatibility Layer Setup](vserver-linux-wine.md) guide to set this up before proceeding.
+You have to complete a one-time installation of the **Wine** compatibility layer if this is your first time using this on your Linux server. Please use our quick [Wine Compatibility Layer Setup](dedicated-linux-wine.md) guide to set this up before proceeding.
 :::
 
 ### Installing Wine
@@ -108,4 +108,4 @@ You should now see logs appear in your command prompt which signals that the sta
 
 ## Conclusion
 
-Congratulations, you have successfully installed and configurated the ARK: Survival Ascended server on your VPS! If you have any further questions or problems, please contact our support team, who are available to help you every day! 
+Congratulations, you have successfully installed and configurated the ARK: Survival Ascended server on your Dedicated Server! If you have any further questions or problems, please contact our support team, who are available to help you every day! 

--- a/docs/dedicated-linux-create-gameservice.md
+++ b/docs/dedicated-linux-create-gameservice.md
@@ -1,7 +1,7 @@
 ---
 id: dedicated-linux-create-gameservice
-title: "Dedicated Server: Setup a Linux Service for your Dedicated Game Server"
-description: Information about setting up a Linux Service for your dedicated game server on a Linux Dedicated Server from ZAP-Hosting - ZAP-Hosting.com documentation
+title: "Dedicated Server: Setup your Dedicated Game Server as a Linux Service"
+description: Information about setting up your dedicated game server as a Linux Service on a Linux Dedicated Server from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: Setup Linux Service
 services:
   - dedicated
@@ -11,7 +11,7 @@ import InlineVoucher from '@site/src/components/InlineVoucher';
 
 ## Introduction
 
-Services are an integral part of Linux and refers to a process or application that runs in the background, either being a pre-defined task or an event-based task. This provides various benefits including automatic server launching on boot, automatic server updates, easy management and access to logs, plus much more! In this guide, we will explore the process of creating a service for your dedicated game servers.
+Services are an integral part of Linux and refers to a process or application that runs in the background, either being a pre-defined task or an event-based task. This provides various benefits including automatic server launching on boot, automatic server updates, easy management and access to logs, plus much more! In this guide, we will explore the process of creating a service for your dedicated game server.
 
 <InlineVoucher />
 

--- a/docs/dedicated-linux-createservice.md
+++ b/docs/dedicated-linux-createservice.md
@@ -1,0 +1,120 @@
+---
+id: dedicated-linux-create-gameservice
+title: "Dedicated Server: Setup a Linux Service for your Dedicated Game Server"
+description: Information about setting up a Linux Service for your dedicated game server on a Linux Dedicated Server from ZAP-Hosting - ZAP-Hosting.com documentation
+sidebar_label: Setup Linux Service
+services:
+  - dedicated
+---
+
+import InlineVoucher from '@site/src/components/InlineVoucher';
+
+## Introduction
+
+Services are an integral part of Linux and refers to a process or application that runs in the background, either being a pre-defined task or an event-based task. This provides various benefits including automatic server launching on boot, automatic server updates, easy management and access to logs, plus much more! In this guide, we will explore the process of creating a service for your dedicated game servers.
+
+<InlineVoucher />
+
+## Preparation
+
+To begin with, connect to your dedicated server via SSH. Use our [SSH Initial Access](vserver-linux-ssh.md) guide if you need help doing this.
+
+You should also follow one of our dedicated game server guides in this section to install and setup a game server on your Linux system. In this guide, we will use the [Palworld dedicated game server](dedicated-linux-palworld.md) as an example, but the instructions can be adapted for all of our guides.
+
+## Creating a Service
+
+Begin by creating a new service file for the dedicated game server that you have setup. Replace `[your_game]` with your choice of name. We recommend using the game's name to keep things organised, thus we will use `palworld.service`.
+```
+sudo nano /etc/systemd/system/[your_game].service
+```
+
+## Setting up Service
+
+With the nano editor now open, copy the following core file contents which is a template service file that you can reuse.
+```
+[Unit]
+Description=[your_server] Server
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+User=steam
+Group=steam
+WorkingDirectory=/home/steam/[your_server_folder]
+ExecStartPre=/usr/games/steamcmd +force_install_dir '/home/steam/[your_server_folder]' +login anonymous +app_update [your_game_steamid] +quit
+ExecStart=/home/steam/[your_server_folder]/[your_path_to_start_file]
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Let's break down the file contents to help understand everything.
+- `Description`: This can be anything, useful to easily distinguish the purpose of the service.
+- `User`: Using our guides, you should have setup a separate `steam` user for use with SteamCMD. If not, this should be set to the user that should run the service.
+- `WorkingDirectory`: This is the path to the main directory which contains everything the service requires.
+- `ExecStartPre`: In this field, we essentially setup the same SteamCMD installation command as before, which will run every time the server is restarted to ensure it is up-to-date. You should copy this from the respective dedicated game server guide, or replace the values manually with the values of the game.
+- `ExecStart`: This field determines the pre-defined task that should run with the service. Once again, you should copy the path from the respective dedicated game server guide, or replace the values manually to navigate to the start file.
+
+:::important Wine Compatibility Layer
+For games that require the **Wine** compatibility layer to be able to run, you should include the **xvfb-run** and **wine** commands within the `ExecStart` parameter. As an example for V-Rising:
+```
+/usr/bin/xvfb-run wine /home/steam/V-Rising-Server/start_server.bat
+```
+
+Please also ensure that your `ExecStartPre` SteamCMD installation command also includes the `+@sSteamCmdForcePlatformType` parameter if necessary to force a platform version.
+:::
+
+With all the input values now adapted to your dedicated game server, you can save the file and quit nano by using `CTRL + X`, followed by `Y` to confirm and lastly `ENTER`.
+
+Using our Palworld example, our file would look like the following:
+```
+[Unit]
+Description=Palworld Server
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+User=steam
+Group=steam
+WorkingDirectory=/home/steam/Palworld-Server
+ExecStartPre=/usr/games/steamcmd +force_install_dir '/home/steam/Palworld-Server' +login anonymous +app_update 2394010 +quit
+ExecStart=/home/steam/Palworld-Server/PalServer.sh
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+```
+
+## Managing Service
+
+With your service file now created, you will need to enable it. With the `palworld.service` example, `[your_service]` is replaced with just `palworld`.
+```
+sudo systemctl enable [your_service]
+```
+
+:::tip
+If at any point you perform changes to your service file, make sure to run `systemctl daemon-reload` afterwards to ensure that the changes take effect.
+:::
+
+You can now start the server with the `systemctl start` command. Likewise, you can easily stop and restart the server with similar commands.
+```
+sudo systemctl start [your_service]
+sudo systemctl stop [your_service]
+sudo systemctl restart [your_service]
+```
+
+:::tip
+To view details about the service, you can use the `systemctl status` command. If you require logs for debugging purposes, you can use the `journalctl -u [your_service].service` command to view the latest logs from the service.
+:::
+
+Lastly, if you ever wish to stop the service from running on start up, simply disable it.
+```
+sudo systemctl disable [your_service]
+```
+
+## Conclusion
+
+You have now successfully setup a service for your dedicated game server. The server will now automatically start upon server boot.
+
+You have also learnt about the contents of the service file as well as how to manage the service using a variety of commands.

--- a/docs/dedicated-linux-enshrouded.md
+++ b/docs/dedicated-linux-enshrouded.md
@@ -1,33 +1,33 @@
 ---
-id: vserver-linux-enshrouded
-title: "VPS: Enshrouded Dedicated Server Linux Setup"
-description: Information about setting up an Enshrouded Dedicated Server on a Linux VPS from ZAP-Hosting - ZAP-Hosting.com documentation
+id: dedicated-linux-enshrouded
+title: "Dedicated Server: Enshrouded Dedicated Server Linux Setup"
+description: Information about setting up an Enshrouded Dedicated Server on a Linux Dedicated Server from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: Enshrouded
 services:
-  - vserver
+  - dedicated
 ---
 
 import InlineVoucher from '@site/src/components/InlineVoucher';
 
 ## Introduction
-Do you have a Linux VPS or root server and you want to install the Enshrouded Dedicated server service on it? You are in the right place. In this guide, we will explain the step by step process of installing this service on your Linux server through the use of SteamCMD. We will be using Ubuntu in the examples, but the process should be very similar for other distributions.
+Do you have a Linux Dedicated Server and you want to install the Enshrouded Dedicated server service on it? You are in the right place. In this guide, we will explain the step by step process of installing this service on your Linux server through the use of SteamCMD. We will be using Ubuntu in the examples, but the process should be very similar for other distributions.
 
 :::tip
-Did you know that you can install our **ZAP GS/TS3 Interface** directly onto your VPS or root server, allowing you to setup game server services, with direct integration to your ZAP-Hosting dashboard, in just a few clicks! Learn more about the [GS/TS3 Interface here](vserver-linux-gs-interface.md).
+Did you know that you can install our **ZAP GS/TS3 Interface** directly onto your dedicated server, allowing you to setup game server services, with direct integration to your ZAP-Hosting dashboard, in just a few clicks! Learn more about the [GS/TS3 Interface here](dedicated-linux-gs-interface.md).
 :::
 
 <InlineVoucher />
 
 ## Preparation
 
-To begin with, connect to your VPS or root server via SSH. Use our [SSH Initial Access](vserver-linux-ssh.md) guide if you need help doing this.
+To begin with, connect to your Dedicated Server via SSH. Use our [SSH Initial Access](vserver-linux-ssh.md) guide if you need help doing this.
 
-You will also have to complete a first-time setup for SteamCMD if this is your first time using this on your Linux server. Please use our [SteamCMD Linux Setup](vserver-linux-steamcmd.md) guide and ensure SteamCMD is fully setup before proceeding.
+You will also have to complete a first-time setup for SteamCMD if this is your first time using this on your Linux server. Please use our [SteamCMD Linux Setup](dedicated-linux-steamcmd.md) guide and ensure SteamCMD is fully setup before proceeding.
 
 :::info Wine Compatibility Layer
 Enshrouded currently does not offer a native Linux-based server build, which means that there is an extra preparation step necessary to run the Windows server build on Linux.
 
-You have to complete a one-time installation of the **Wine** compatibility layer if this is your first time using this on your Linux server. Please use our quick [Wine Compatibility Layer Setup](vserver-linux-wine.md) guide to set this up before proceeding.
+You have to complete a one-time installation of the **Wine** compatibility layer if this is your first time using this on your Linux server. Please use our quick [Wine Compatibility Layer Setup](dedicated-linux-wine.md) guide to set this up before proceeding.
 :::
 
 ## Installation
@@ -67,4 +67,4 @@ You should now see many logs appear in your command prompt. If you see the `[Ses
 
 ## Conclusion
 
-Congratulations, you have successfully installed and configurated the Enshrouded server on your VPS! If you have any further questions or problems, please contact our support team, who are available to help you every day! 
+Congratulations, you have successfully installed and configurated the Enshrouded server on your Dedicated Server! If you have any further questions or problems, please contact our support team, who are available to help you every day! 

--- a/docs/dedicated-linux-enshrouded.md
+++ b/docs/dedicated-linux-enshrouded.md
@@ -58,9 +58,9 @@ See our [Enshrouded Server Configuration guide](enshrouded-configuration.md) to 
 
 ## Starting & Connecting to your server
 
-Now it is time to start your server. Head over to the main game directory and run the **enshrouded_server.exe** executable file using the command below. Ensure that you add the **wine64** command to run it through the Wine compatibility layer.
+Now it is time to start your server. Head over to the main game directory and run the **enshrouded_server.exe** executable file using the command below. Ensure that you add the **xvfb-run** and **wine** commands to run it through the Wine compatibility layer.
 ```
-wine64 /home/steam/Enshrouded-Server/enshrouded_server.exe
+xvfb-run wine /home/steam/Enshrouded-Server/enshrouded_server.exe
 ```
 
 You should now see many logs appear in your command prompt. If you see the `[Session] 'HostOnline' (up)!` log message, this signals that the start up was successful. You will be able to connect directly by adding the server details in the **Find Games** tab: `[your_ip_address]:15636`.

--- a/docs/dedicated-linux-enshrouded.md
+++ b/docs/dedicated-linux-enshrouded.md
@@ -67,4 +67,6 @@ You should now see many logs appear in your command prompt. If you see the `[Ses
 
 ## Conclusion
 
-Congratulations, you have successfully installed and configurated the Enshrouded server on your Dedicated Server! If you have any further questions or problems, please contact our support team, who are available to help you every day! 
+Congratulations, you have successfully installed and configurated the Enshrouded server on your Dedicated Server! As a next step, we recommend looking over our [Setup Linux Service](dedicated-linux-create-gameservice.md) guide, which covers setting up your new dedicated game server as a service. This provides various benefits including automatic server launching on boot, automatic server updates, easy management and access to logs, plus much more!
+
+If you have any further questions or problems, please contact our support team, who are available to help you every day!

--- a/docs/dedicated-linux-foundry.md
+++ b/docs/dedicated-linux-foundry.md
@@ -67,4 +67,6 @@ You should now see logs appear in your command prompt which signals that the sta
 
 ## Conclusion
 
-Congratulations, you have successfully installed and configurated the Foundry server on your Dedicated Server! If you have any further questions or problems, please contact our support team, who are available to help you every day! 
+Congratulations, you have successfully installed and configurated the Foundry server on your Dedicated Server! As a next step, we recommend looking over our [Setup Linux Service](dedicated-linux-create-gameservice.md) guide, which covers setting up your new dedicated game server as a service. This provides various benefits including automatic server launching on boot, automatic server updates, easy management and access to logs, plus much more!
+
+If you have any further questions or problems, please contact our support team, who are available to help you every day!

--- a/docs/dedicated-linux-foundry.md
+++ b/docs/dedicated-linux-foundry.md
@@ -1,33 +1,33 @@
 ---
-id: vserver-linux-foundry
-title: "VPS: Foundry Dedicated Server Linux Setup"
-description: Information about setting up an Foundry Dedicated Server on a Linux VPS from ZAP-Hosting - ZAP-Hosting.com documentation
+id: dedicated-linux-foundry
+title: "Dedicated Server: Foundry Dedicated Server Linux Setup"
+description: Information about setting up an Foundry Dedicated Server on a Linux Dedicated Server from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: Foundry
 services:
-  - vserver
+  - dedicated
 ---
 
 import InlineVoucher from '@site/src/components/InlineVoucher';
 
 ## Introduction
-Do you have a Linux VPS or root server and you want to install the Foundry Dedicated server service on it? You are in the right place. In this guide, we will explain the step by step process of installing this service on your Linux server through the use of SteamCMD. We will be using Ubuntu in the examples, but the process should be very similar for other distributions.
+Do you have a Linux Dedicated Server and you want to install the Foundry Dedicated server service on it? You are in the right place. In this guide, we will explain the step by step process of installing this service on your Linux server through the use of SteamCMD. We will be using Ubuntu in the examples, but the process should be very similar for other distributions.
 
 :::tip
-Did you know that you can install our **ZAP GS/TS3 Interface** directly onto your VPS or root server, allowing you to setup game server services, with direct integration to your ZAP-Hosting dashboard, in just a few clicks! Learn more about the [GS/TS3 Interface here](vserver-linux-gs-interface.md).
+Did you know that you can install our **ZAP GS/TS3 Interface** directly onto your dedicated server, allowing you to setup game server services, with direct integration to your ZAP-Hosting dashboard, in just a few clicks! Learn more about the [GS/TS3 Interface here](dedicated-linux-gs-interface.md).
 :::
 
 <InlineVoucher />
 
 ## Preparation
 
-To begin with, connect to your VPS or root server via SSH. Use our [SSH Initial Access](vserver-linux-ssh.md) guide if you need help doing this.
+To begin with, connect to your Dedicated Server via SSH. Use our [SSH Initial Access](vserver-linux-ssh.md) guide if you need help doing this.
 
-You will also have to complete a first-time setup for SteamCMD if this is your first time using this on your Linux server. Please use our [SteamCMD Linux Setup](vserver-linux-steamcmd.md) guide and ensure SteamCMD is fully setup before proceeding.
+You will also have to complete a first-time setup for SteamCMD if this is your first time using this on your Linux server. Please use our [SteamCMD Linux Setup](dedicated-linux-steamcmd.md) guide and ensure SteamCMD is fully setup before proceeding.
 
 :::info Wine Compatibility Layer
 Foundry currently does not offer a native Linux-based server build, which means that there is an extra preparation step necessary to run the Windows server build on Linux.
 
-You have to complete a one-time installation of the **Wine** compatibility layer if this is your first time using this on your Linux server. Please use our quick [Wine Compatibility Layer Setup](vserver-linux-wine.md) guide to set this up before proceeding.
+You have to complete a one-time installation of the **Wine** compatibility layer if this is your first time using this on your Linux server. Please use our quick [Wine Compatibility Layer Setup](dedicated-linux-wine.md) guide to set this up before proceeding.
 :::
 
 ## Installation
@@ -67,4 +67,4 @@ You should now see logs appear in your command prompt which signals that the sta
 
 ## Conclusion
 
-Congratulations, you have successfully installed and configurated the Foundry server on your VPS! If you have any further questions or problems, please contact our support team, who are available to help you every day! 
+Congratulations, you have successfully installed and configurated the Foundry server on your Dedicated Server! If you have any further questions or problems, please contact our support team, who are available to help you every day! 

--- a/docs/dedicated-linux-mythofempires.md
+++ b/docs/dedicated-linux-mythofempires.md
@@ -1,33 +1,33 @@
 ---
-id: vserver-linux-mythofempires
-title: "VPS: Myth of Empires Dedicated Server Linux Setup"
-description: Information about setting up an Myth of Empires Dedicated Server on a Linux VPS from ZAP-Hosting - ZAP-Hosting.com documentation
+id: dedicated-linux-mythofempires
+title: "Dedicated Server: Myth of Empires Dedicated Server Linux Setup"
+description: Information about setting up an Myth of Empires Dedicated Server on a Linux Dedicated Server from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: Myth of Empires
 services:
-  - vserver
+  - dedicated
 ---
 
 import InlineVoucher from '@site/src/components/InlineVoucher';
 
 ## Introduction
-Do you have a Linux VPS or root server and you want to install the Myth of Empires Dedicated server service on it? You are in the right place. In this guide, we will explain the step by step process of installing this service on your Linux server through the use of SteamCMD. We will be using Ubuntu in the examples, but the process should be very similar for other distributions.
+Do you have a Linux Dedicated Server and you want to install the Myth of Empires Dedicated server service on it? You are in the right place. In this guide, we will explain the step by step process of installing this service on your Linux server through the use of SteamCMD. We will be using Ubuntu in the examples, but the process should be very similar for other distributions.
 
 :::tip
-Did you know that you can install our **ZAP GS/TS3 Interface** directly onto your VPS or root server, allowing you to setup game server services, with direct integration to your ZAP-Hosting dashboard, in just a few clicks! Learn more about the [GS/TS3 Interface here](vserver-linux-gs-interface.md).
+Did you know that you can install our **ZAP GS/TS3 Interface** directly onto your dedicated server, allowing you to setup game server services, with direct integration to your ZAP-Hosting dashboard, in just a few clicks! Learn more about the [GS/TS3 Interface here](dedicated-linux-gs-interface.md).
 :::
 
 <InlineVoucher />
 
 ## Preparation
 
-To begin with, connect to your VPS or root server via SSH. Use our [SSH Initial Access](vserver-linux-ssh.md) guide if you need help doing this.
+To begin with, connect to your Dedicated Server via SSH. Use our [SSH Initial Access](vserver-linux-ssh.md) guide if you need help doing this.
 
-You will also have to complete a first-time setup for SteamCMD if this is your first time using this on your Linux server. Please use our [SteamCMD Linux Setup](vserver-linux-steamcmd.md) guide and ensure SteamCMD is fully setup before proceeding.
+You will also have to complete a first-time setup for SteamCMD if this is your first time using this on your Linux server. Please use our [SteamCMD Linux Setup](dedicated-linux-steamcmd.md) guide and ensure SteamCMD is fully setup before proceeding.
 
 :::info Wine Compatibility Layer
 Myth of Empires currently does not offer a native Linux-based server build, which means that there is an extra preparation step necessary to run the Windows server build on Linux.
 
-You have to complete a one-time installation of the **Wine** compatibility layer if this is your first time using this on your Linux server. Please use our quick [Wine Compatibility Layer Setup](vserver-linux-wine.md) guide to set this up before proceeding.
+You have to complete a one-time installation of the **Wine** compatibility layer if this is your first time using this on your Linux server. Please use our quick [Wine Compatibility Layer Setup](dedicated-linux-wine.md) guide to set this up before proceeding.
 :::
 
 ## Installation
@@ -69,4 +69,4 @@ You should now see logs appear in your command prompt which signals that the sta
 
 ## Conclusion
 
-Congratulations, you have successfully installed and configurated the Myth of Empires server on your VPS! If you have any further questions or problems, please contact our support team, who are available to help you every day! 
+Congratulations, you have successfully installed and configurated the Myth of Empires server on your Dedicated Server! If you have any further questions or problems, please contact our support team, who are available to help you every day! 

--- a/docs/dedicated-linux-mythofempires.md
+++ b/docs/dedicated-linux-mythofempires.md
@@ -69,4 +69,6 @@ You should now see logs appear in your command prompt which signals that the sta
 
 ## Conclusion
 
-Congratulations, you have successfully installed and configurated the Myth of Empires server on your Dedicated Server! If you have any further questions or problems, please contact our support team, who are available to help you every day! 
+Congratulations, you have successfully installed and configurated the Myth of Empires server on your Dedicated Server! As a next step, we recommend looking over our [Setup Linux Service](dedicated-linux-create-gameservice.md) guide, which covers setting up your new dedicated game server as a service. This provides various benefits including automatic server launching on boot, automatic server updates, easy management and access to logs, plus much more!
+
+If you have any further questions or problems, please contact our support team, who are available to help you every day!

--- a/docs/dedicated-linux-palworld.md
+++ b/docs/dedicated-linux-palworld.md
@@ -1,28 +1,28 @@
 ---
-id: vserver-linux-palworld
-title: "VPS: Palworld Dedicated Server Linux Setup"
-description: Information about setting up an Palworld Dedicated Server on a Linux VPS from ZAP-Hosting - ZAP-Hosting.com documentation
+id: dedicated-linux-palworld
+title: "Dedicated Server: Palworld Dedicated Server Linux Setup"
+description: Information about setting up an Palworld Dedicated Server on a Linux Dedicated Server from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: Palworld
 services:
-  - vserver
+  - dedicated
 ---
 
 import InlineVoucher from '@site/src/components/InlineVoucher';
 
 ## Introduction
-Do you have a Linux VPS or root server and you want to install the Palworld Dedicated server service on it? You are in the right place. In this guide, we will explain the step by step process of installing this service on your Linux server through the use of SteamCMD. We will be using Ubuntu in the examples, but the process should be very similar for other distributions.
+Do you have a Linux Dedicated Server and you want to install the Palworld Dedicated server service on it? You are in the right place. In this guide, we will explain the step by step process of installing this service on your Linux server through the use of SteamCMD. We will be using Ubuntu in the examples, but the process should be very similar for other distributions.
 
 :::tip
-Did you know that you can install our **ZAP GS/TS3 Interface** directly onto your VPS or root server, allowing you to setup game server services, with direct integration to your ZAP-Hosting dashboard, in just a few clicks! Learn more about the [GS/TS3 Interface here](vserver-linux-gs-interface.md).
+Did you know that you can install our **ZAP GS/TS3 Interface** directly onto your dedicated server, allowing you to setup game server services, with direct integration to your ZAP-Hosting dashboard, in just a few clicks! Learn more about the [GS/TS3 Interface here](dedicated-linux-gs-interface.md).
 :::
 
 <InlineVoucher />
 
 ## Preparation
 
-To begin with, connect to your VPS or root server via SSH. Use our [SSH Initial Access](vserver-linux-ssh.md) guide if you need help doing this.
+To begin with, connect to your Dedicated Server via SSH. Use our [SSH Initial Access](vserver-linux-ssh.md) guide if you need help doing this.
 
-You will also have to complete a first-time setup for SteamCMD if this is your first time using this on your Linux server. Please use our [SteamCMD Linux Setup](vserver-linux-steamcmd.md) guide and ensure SteamCMD is fully setup before proceeding.
+You will also have to complete a first-time setup for SteamCMD if this is your first time using this on your Linux server. Please use our [SteamCMD Linux Setup](dedicated-linux-steamcmd.md) guide and ensure SteamCMD is fully setup before proceeding.
 
 ## Installation
 
@@ -66,4 +66,4 @@ You should now see logs appear in your command prompt, including a game version 
 
 ## Conclusion
 
-Congratulations, you have successfully installed and configurated the Palworld server on your VPS! If you have any further questions or problems, please contact our support team, who are available to help you every day! 
+Congratulations, you have successfully installed and configurated the Palworld server on your Dedicated Server! If you have any further questions or problems, please contact our support team, who are available to help you every day! 

--- a/docs/dedicated-linux-palworld.md
+++ b/docs/dedicated-linux-palworld.md
@@ -66,4 +66,6 @@ You should now see logs appear in your command prompt, including a game version 
 
 ## Conclusion
 
-Congratulations, you have successfully installed and configurated the Palworld server on your Dedicated Server! If you have any further questions or problems, please contact our support team, who are available to help you every day! 
+Congratulations, you have successfully installed and configurated the Palworld server on your Dedicated Server! As a next step, we recommend looking over our [Setup Linux Service](dedicated-linux-create-gameservice.md) guide, which covers setting up your new dedicated game server as a service. This provides various benefits including automatic server launching on boot, automatic server updates, easy management and access to logs, plus much more!
+
+If you have any further questions or problems, please contact our support team, who are available to help you every day!

--- a/docs/dedicated-linux-satisfactory.md
+++ b/docs/dedicated-linux-satisfactory.md
@@ -1,28 +1,28 @@
 ---
-id: vserver-linux-satisfactory
-title: "VPS: Satisfactory Dedicated Server Linux Setup"
-description: Information about setting up an Satisfactory Dedicated Server on a Linux VPS from ZAP-Hosting - ZAP-Hosting.com documentation
+id: dedicated-linux-satisfactory
+title: "Dedicated Server: Satisfactory Dedicated Server Linux Setup"
+description: Information about setting up an Satisfactory Dedicated Server on a Linux Dedicated Server from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: Satisfactory
 services:
-  - vserver
+  - dedicated
 ---
 
 import InlineVoucher from '@site/src/components/InlineVoucher';
 
 ## Introduction
-Do you have a Linux VPS or root server and you want to install the Satisfactory Dedicated server service on it? You are in the right place. In this guide, we will explain the step by step process of installing this service on your Linux server through the use of SteamCMD. We will be using Ubuntu in the examples, but the process should be very similar for other distributions.
+Do you have a Linux Dedicated Server and you want to install the Satisfactory Dedicated server service on it? You are in the right place. In this guide, we will explain the step by step process of installing this service on your Linux server through the use of SteamCMD. We will be using Ubuntu in the examples, but the process should be very similar for other distributions.
 
 :::tip
-Did you know that you can install our **ZAP GS/TS3 Interface** directly onto your VPS or root server, allowing you to setup game server services, with direct integration to your ZAP-Hosting dashboard, in just a few clicks! Learn more about the [GS/TS3 Interface here](vserver-linux-gs-interface.md).
+Did you know that you can install our **ZAP GS/TS3 Interface** directly onto your dedicated server, allowing you to setup game server services, with direct integration to your ZAP-Hosting dashboard, in just a few clicks! Learn more about the [GS/TS3 Interface here](dedicated-linux-gs-interface.md).
 :::
 
 <InlineVoucher />
 
 ## Preparation
 
-To begin with, connect to your VPS or root server via SSH. Use our [SSH Initial Access](vserver-linux-ssh.md) guide if you need help doing this.
+To begin with, connect to your Dedicated Server via SSH. Use our [SSH Initial Access](vserver-linux-ssh.md) guide if you need help doing this.
 
-You will also have to complete a first-time setup for SteamCMD if this is your first time using this on your Linux server. Please use our [SteamCMD Linux Setup](vserver-linux-steamcmd.md) guide and ensure SteamCMD is fully setup before proceeding.
+You will also have to complete a first-time setup for SteamCMD if this is your first time using this on your Linux server. Please use our [SteamCMD Linux Setup](dedicated-linux-steamcmd.md) guide and ensure SteamCMD is fully setup before proceeding.
 
 ## Installation
 
@@ -60,4 +60,4 @@ You should now see logs appear in your command prompt which signals that the sta
 
 ## Conclusion
 
-Congratulations, you have successfully installed and configurated the Satisfactory server on your VPS! If you have any further questions or problems, please contact our support team, who are available to help you every day! 
+Congratulations, you have successfully installed and configurated the Satisfactory server on your Dedicated Server! If you have any further questions or problems, please contact our support team, who are available to help you every day! 

--- a/docs/dedicated-linux-satisfactory.md
+++ b/docs/dedicated-linux-satisfactory.md
@@ -60,4 +60,6 @@ You should now see logs appear in your command prompt which signals that the sta
 
 ## Conclusion
 
-Congratulations, you have successfully installed and configurated the Satisfactory server on your Dedicated Server! If you have any further questions or problems, please contact our support team, who are available to help you every day! 
+Congratulations, you have successfully installed and configurated the Satisfactory server on your Dedicated Server! As a next step, we recommend looking over our [Setup Linux Service](dedicated-linux-create-gameservice.md) guide, which covers setting up your new dedicated game server as a service. This provides various benefits including automatic server launching on boot, automatic server updates, easy management and access to logs, plus much more!
+
+If you have any further questions or problems, please contact our support team, who are available to help you every day!

--- a/docs/dedicated-linux-soulmask.md
+++ b/docs/dedicated-linux-soulmask.md
@@ -59,4 +59,6 @@ You should now see logs appear in your command prompt which signals that the sta
 
 ## Conclusion
 
-Congratulations, you have successfully installed and configurated the Soulmask server on your Dedicated Server! If you have any further questions or problems, please contact our support team, who are available to help you every day! 
+Congratulations, you have successfully installed and configurated the Soulmask server on your Dedicated Server! As a next step, we recommend looking over our [Setup Linux Service](dedicated-linux-create-gameservice.md) guide, which covers setting up your new dedicated game server as a service. This provides various benefits including automatic server launching on boot, automatic server updates, easy management and access to logs, plus much more!
+
+If you have any further questions or problems, please contact our support team, who are available to help you every day!

--- a/docs/dedicated-linux-soulmask.md
+++ b/docs/dedicated-linux-soulmask.md
@@ -1,28 +1,28 @@
 ---
-id: vserver-linux-soulmask
-title: "VPS: Soulmask Dedicated Server Linux Setup"
-description: Information about setting up an Soulmask Dedicated Server on a Linux VPS from ZAP-Hosting - ZAP-Hosting.com documentation
+id: dedicated-linux-soulmask
+title: "Dedicated Server: Soulmask Dedicated Server Linux Setup"
+description: Information about setting up an Soulmask Dedicated Server on a Linux Dedicated Server from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: Soulmask
 services:
-  - vserver
+  - dedicated
 ---
 
 import InlineVoucher from '@site/src/components/InlineVoucher';
 
 ## Introduction
-Do you have a Linux VPS or root server and you want to install the Soulmask Dedicated server service on it? You are in the right place. In this guide, we will explain the step by step process of installing this service on your Linux server through the use of SteamCMD. We will be using Ubuntu in the examples, but the process should be very similar for other distributions.
+Do you have a Linux Dedicated Server and you want to install the Soulmask Dedicated server service on it? You are in the right place. In this guide, we will explain the step by step process of installing this service on your Linux server through the use of SteamCMD. We will be using Ubuntu in the examples, but the process should be very similar for other distributions.
 
 :::tip
-Did you know that you can install our **ZAP GS/TS3 Interface** directly onto your VPS or root server, allowing you to setup game server services, with direct integration to your ZAP-Hosting dashboard, in just a few clicks! Learn more about the [GS/TS3 Interface here](vserver-linux-gs-interface.md).
+Did you know that you can install our **ZAP GS/TS3 Interface** directly onto your dedicated server, allowing you to setup game server services, with direct integration to your ZAP-Hosting dashboard, in just a few clicks! Learn more about the [GS/TS3 Interface here](dedicated-linux-gs-interface.md).
 :::
 
 <InlineVoucher />
 
 ## Preparation
 
-To begin with, connect to your VPS or root server via SSH. Use our [SSH Initial Access](vserver-linux-ssh.md) guide if you need help doing this.
+To begin with, connect to your Dedicated Server via SSH. Use our [SSH Initial Access](vserver-linux-ssh.md) guide if you need help doing this.
 
-You will also have to complete a first-time setup for SteamCMD if this is your first time using this on your Linux server. Please use our [SteamCMD Linux Setup](vserver-linux-steamcmd.md) guide and ensure SteamCMD is fully setup before proceeding.
+You will also have to complete a first-time setup for SteamCMD if this is your first time using this on your Linux server. Please use our [SteamCMD Linux Setup](dedicated-linux-steamcmd.md) guide and ensure SteamCMD is fully setup before proceeding.
 
 ## Installation
 
@@ -59,4 +59,4 @@ You should now see logs appear in your command prompt which signals that the sta
 
 ## Conclusion
 
-Congratulations, you have successfully installed and configurated the Soulmask server on your VPS! If you have any further questions or problems, please contact our support team, who are available to help you every day! 
+Congratulations, you have successfully installed and configurated the Soulmask server on your Dedicated Server! If you have any further questions or problems, please contact our support team, who are available to help you every day! 

--- a/docs/dedicated-linux-steamcmd.md
+++ b/docs/dedicated-linux-steamcmd.md
@@ -1,10 +1,10 @@
 ---
-id: vserver-linux-steamcmd
-title: "VPS: SteamCMD Linux Setup"
-description: Information about setting up SteamCMD on a Linux VPS from ZAP-Hosting - ZAP-Hosting.com documentation
+id: dedicated-linux-steamcmd
+title: "Dedicated Server: SteamCMD Linux Setup"
+description: Information about setting up SteamCMD on a Linux Dedicated Server from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: Setup SteamCMD
 services:
-  - vserver
+  - dedicated
 ---
 
 import InlineVoucher from '@site/src/components/InlineVoucher';
@@ -16,7 +16,7 @@ SteamCMD is an essential tool that is necessary for installing dedicated servers
 
 ## Preparation
 
-To begin with, connect to your VPS or root server via SSH. Use our [SSH Initial Access](vserver-linux-ssh.md) guide if you need help doing this.
+To begin with, connect to your Dedicated Server via SSH. Use our [SSH Initial Access](vserver-linux-ssh.md) guide if you need help doing this.
 
 ## Installing SteamCMD
 

--- a/docs/dedicated-linux-steamcmd.md
+++ b/docs/dedicated-linux-steamcmd.md
@@ -98,7 +98,7 @@ export PATH="/usr/games/:$PATH"
 
 Save the file and quit nano by using `CTRL + X`, followed by `Y` to confirm and lastly `ENTER`.
 
-### Conclusion
+## Conclusion
 
 You have now successfully setup the core SteamCMD functionality for your Linux server. You can now proceed with installing Steam content through the `steam` user.
 

--- a/docs/dedicated-linux-valheim.md
+++ b/docs/dedicated-linux-valheim.md
@@ -70,4 +70,6 @@ Once installed, use the following command to launch the Windows version through 
 
 ## Conclusion
 
-Congratulations, you have successfully installed and configurated the Valheim server on your Dedicated Server! If you have any further questions or problems, please contact our support team, who are available to help you every day! 
+Congratulations, you have successfully installed and configurated the Valheim server on your Dedicated Server! As a next step, we recommend looking over our [Setup Linux Service](dedicated-linux-create-gameservice.md) guide, which covers setting up your new dedicated game server as a service. This provides various benefits including automatic server launching on boot, automatic server updates, easy management and access to logs, plus much more!
+
+If you have any further questions or problems, please contact our support team, who are available to help you every day!

--- a/docs/dedicated-linux-valheim.md
+++ b/docs/dedicated-linux-valheim.md
@@ -1,28 +1,28 @@
 ---
-id: vserver-linux-valheim
-title: "VPS: Valheim Dedicated Server Linux Setup"
-description: Information about setting up an Valheim Dedicated Server on a Linux VPS from ZAP-Hosting - ZAP-Hosting.com documentation
+id: dedicated-linux-valheim
+title: "Dedicated Server: Valheim Dedicated Server Linux Setup"
+description: Information about setting up an Valheim Dedicated Server on a Linux Dedicated Server from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: Valheim
 services:
-  - vserver
+  - dedicated
 ---
 
 import InlineVoucher from '@site/src/components/InlineVoucher';
 
 ## Introduction
-Do you have a Linux VPS or root server and you want to install the Valheim Dedicated server service on it? You are in the right place. In this guide, we will explain the step by step process of installing this service on your Linux server through the use of SteamCMD. We will be using Ubuntu in the examples, but the process should be very similar for other distributions.
+Do you have a Linux Dedicated Server and you want to install the Valheim Dedicated server service on it? You are in the right place. In this guide, we will explain the step by step process of installing this service on your Linux server through the use of SteamCMD. We will be using Ubuntu in the examples, but the process should be very similar for other distributions.
 
 :::tip
-Did you know that you can install our **ZAP GS/TS3 Interface** directly onto your VPS or root server, allowing you to setup game server services, with direct integration to your ZAP-Hosting dashboard, in just a few clicks! Learn more about the [GS/TS3 Interface here](vserver-linux-gs-interface.md).
+Did you know that you can install our **ZAP GS/TS3 Interface** directly onto your dedicated server, allowing you to setup game server services, with direct integration to your ZAP-Hosting dashboard, in just a few clicks! Learn more about the [GS/TS3 Interface here](dedicated-linux-gs-interface.md).
 :::
 
 <InlineVoucher />
 
 ## Preparation
 
-To begin with, connect to your VPS or root server via SSH. Use our [SSH Initial Access](vserver-linux-ssh.md) guide if you need help doing this.
+To begin with, connect to your Dedicated Server via SSH. Use our [SSH Initial Access](vserver-linux-ssh.md) guide if you need help doing this.
 
-You will also have to complete a first-time setup for SteamCMD if this is your first time using this on your Linux server. Please use our [SteamCMD Linux Setup](vserver-linux-steamcmd.md) guide and ensure SteamCMD is fully setup before proceeding.
+You will also have to complete a first-time setup for SteamCMD if this is your first time using this on your Linux server. Please use our [SteamCMD Linux Setup](dedicated-linux-steamcmd.md) guide and ensure SteamCMD is fully setup before proceeding.
 
 ## Installation
 
@@ -60,7 +60,7 @@ You should now see logs appear in your command prompt which signals that the sta
 :::info
 If you cannot connect and receive `PlayFab` errors in console, you may need to disable crossplay support to resolve this as this is a current issue with the Linux version. To do so, run `nano /home/steam/Valheim-Server/start_server.sh` and remove the `-crossplay` flag.
 
-If you do require crossplay, an alternate solution is to instead install the Windows version and use **Wine** as a compatibility layer. Please use our quick [Wine Compatibility Layer Setup](vserver-linux-wine.md) guide to set this up. Once ready, you can install the Valheim Windows server version via SteamCMD using:
+If you do require crossplay, an alternate solution is to instead install the Windows version and use **Wine** as a compatibility layer. Please use our quick [Wine Compatibility Layer Setup](dedicated-linux-wine.md) guide to set this up. Once ready, you can install the Valheim Windows server version via SteamCMD using:
 ```
 steamcmd +@sSteamCmdForcePlatformType windows +force_install_dir '/home/steam/Valheim-Server' +login anonymous +app_update 896660 validate +quit
 ```
@@ -70,4 +70,4 @@ Once installed, use the following command to launch the Windows version through 
 
 ## Conclusion
 
-Congratulations, you have successfully installed and configurated the Valheim server on your VPS! If you have any further questions or problems, please contact our support team, who are available to help you every day! 
+Congratulations, you have successfully installed and configurated the Valheim server on your Dedicated Server! If you have any further questions or problems, please contact our support team, who are available to help you every day! 

--- a/docs/dedicated-linux-vrising.md
+++ b/docs/dedicated-linux-vrising.md
@@ -1,33 +1,33 @@
 ---
-id: vserver-linux-vrising
-title: "VPS: V-Rising Dedicated Server Linux Setup"
-description: Information about setting up an V-Rising Dedicated Server on a Linux VPS from ZAP-Hosting - ZAP-Hosting.com documentation
+id: dedicated-linux-vrising
+title: "Dedicated Server: V-Rising Dedicated Server Linux Setup"
+description: Information about setting up an V-Rising Dedicated Server on a Linux Dedicated Server from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: V-Rising
 services:
-  - vserver
+  - dedicated
 ---
 
 import InlineVoucher from '@site/src/components/InlineVoucher';
 
 ## Introduction
-Do you have a Linux VPS or root server and you want to install the V-Rising Dedicated server service on it? You are in the right place. In this guide, we will explain the step by step process of installing this service on your Linux server through the use of SteamCMD. We will be using Ubuntu in the examples, but the process should be very similar for other distributions.
+Do you have a Linux Dedicated Server and you want to install the V-Rising Dedicated server service on it? You are in the right place. In this guide, we will explain the step by step process of installing this service on your Linux server through the use of SteamCMD. We will be using Ubuntu in the examples, but the process should be very similar for other distributions.
 
 :::tip
-Did you know that you can install our **ZAP GS/TS3 Interface** directly onto your VPS or root server, allowing you to setup game server services, with direct integration to your ZAP-Hosting dashboard, in just a few clicks! Learn more about the [GS/TS3 Interface here](vserver-linux-gs-interface.md).
+Did you know that you can install our **ZAP GS/TS3 Interface** directly onto your dedicated server, allowing you to setup game server services, with direct integration to your ZAP-Hosting dashboard, in just a few clicks! Learn more about the [GS/TS3 Interface here](dedicated-linux-gs-interface.md).
 :::
 
 <InlineVoucher />
 
 ## Preparation
 
-To begin with, connect to your VPS or root server via SSH. Use our [SSH Initial Access](vserver-linux-ssh.md) guide if you need help doing this.
+To begin with, connect to your Dedicated Server via SSH. Use our [SSH Initial Access](vserver-linux-ssh.md) guide if you need help doing this.
 
-You will also have to complete a first-time setup for SteamCMD if this is your first time using this on your Linux server. Please use our [SteamCMD Linux Setup](vserver-linux-steamcmd.md) guide and ensure SteamCMD is fully setup before proceeding.
+You will also have to complete a first-time setup for SteamCMD if this is your first time using this on your Linux server. Please use our [SteamCMD Linux Setup](dedicated-linux-steamcmd.md) guide and ensure SteamCMD is fully setup before proceeding.
 
 :::info Wine Compatibility Layer
 V-Rising currently does not offer a native Linux-based server build, which means that there is an extra preparation step necessary to run the Windows server build on Linux.
 
-You have to complete a one-time installation of the **Wine** compatibility layer if this is your first time using this on your Linux server. Please use our quick [Wine Compatibility Layer Setup](vserver-linux-wine.md) guide to set this up before proceeding.
+You have to complete a one-time installation of the **Wine** compatibility layer if this is your first time using this on your Linux server. Please use our quick [Wine Compatibility Layer Setup](dedicated-linux-wine.md) guide to set this up before proceeding.
 :::
 
 ## Installation
@@ -73,4 +73,4 @@ You should now see logs appear in your command prompt which signals that the sta
 
 ## Conclusion
 
-Congratulations, you have successfully installed and configurated the V-Rising server on your VPS! If you have any further questions or problems, please contact our support team, who are available to help you every day! 
+Congratulations, you have successfully installed and configurated the V-Rising server on your Dedicated Server! If you have any further questions or problems, please contact our support team, who are available to help you every day! 

--- a/docs/dedicated-linux-vrising.md
+++ b/docs/dedicated-linux-vrising.md
@@ -73,4 +73,6 @@ You should now see logs appear in your command prompt which signals that the sta
 
 ## Conclusion
 
-Congratulations, you have successfully installed and configurated the V-Rising server on your Dedicated Server! If you have any further questions or problems, please contact our support team, who are available to help you every day! 
+Congratulations, you have successfully installed and configurated the V-Rising server on your Dedicated Server! As a next step, we recommend looking over our [Setup Linux Service](dedicated-linux-create-gameservice.md) guide, which covers setting up your new dedicated game server as a service. This provides various benefits including automatic server launching on boot, automatic server updates, easy management and access to logs, plus much more!
+
+If you have any further questions or problems, please contact our support team, who are available to help you every day!

--- a/docs/dedicated-linux-wine.md
+++ b/docs/dedicated-linux-wine.md
@@ -1,10 +1,10 @@
 ---
-id: vserver-linux-wine
-title: "VPS: Wine Compatibility Layer Linux Setup"
-description: Information about setting up the Wine (WineHQ) Windows compatibility layer on a Linux VPS from ZAP-Hosting - ZAP-Hosting.com documentation
+id: dedicated-linux-wine
+title: "Dedicated Server: Wine Compatibility Layer Linux Setup"
+description: Information about setting up the Wine (WineHQ) Windows compatibility layer on a Linux Dedicated Server from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: Setup Wine Compatibility Layer
 services:
-  - vserver
+  - dedicated
 ---
 
 import InlineVoucher from '@site/src/components/InlineVoucher';
@@ -17,7 +17,7 @@ Wine is an open-source compatibility layer for Linux which allows software that 
 
 ## Preparation
 
-To begin with, connect to your VPS or root server via SSH. Use our [SSH Initial Access](vserver-linux-ssh.md) guide if you need help doing this.
+To begin with, connect to your Dedicated Server via SSH. Use our [SSH Initial Access](vserver-linux-ssh.md) guide if you need help doing this.
 
 ## Installing Wine
 

--- a/docs/dedicated-linux-wine.md
+++ b/docs/dedicated-linux-wine.md
@@ -51,7 +51,7 @@ Finally, you need to install a few extra packages to ensure that Wine will work 
 sudo apt install cabextract winbind screen xvfb
 ```
 
-### Conclusion
+## Conclusion
 
 You have now successfully setup the Wine comaptibility layer, which will allow you to run Windows programs on your Linux server. With this important prerequisite installed, you can now proceed to install dedicated game servers even if they are built for Windows.
 

--- a/docs/dedicated-windows-ark.md
+++ b/docs/dedicated-windows-ark.md
@@ -1,6 +1,6 @@
 ---
 id: dedicated-windows-ark
-title: "Dedicated Server: ARK Survival Evolved Dedicated Server Setup"
+title: "Dedicated Server: ARK Survival Evolved Dedicated Server Windows Setup"
 description: Information about setting up an ARK Survival Evolved Dedicated Server on a Dedicated Server - ZAP-Hosting.com documentation
 sidebar_label: ARK Survival Evolved Dedicated Server Setup
 services:

--- a/docs/dedicated-windows-arksurvivalascended.md
+++ b/docs/dedicated-windows-arksurvivalascended.md
@@ -1,6 +1,6 @@
 ---
 id: dedicated-windows-arksurvivalascended
-title: "Dedicated Server: ARK Survival Ascended Dedicated Server Setup"
+title: "Dedicated Server: ARK Survival Ascended Dedicated Server Windows Setup"
 description: Information about setting up an ARK Survival Ascended Dedicated Server on a Windows Dedicated Server from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: ARK Survival Ascended
 services:

--- a/docs/dedicated-windows-arksurvivalascended.md
+++ b/docs/dedicated-windows-arksurvivalascended.md
@@ -1,7 +1,7 @@
 ---
 id: dedicated-windows-arksurvivalascended
 title: "Dedicated Server: ARK Survival Ascended Dedicated Server Setup"
-description: Information about setting up an ARK Survival Ascended Dedicated Server on a Dedicated Server - ZAP-Hosting.com documentation
+description: Information about setting up an ARK Survival Ascended Dedicated Server on a Windows Dedicated Server from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: ARK Survival Ascended
 services:
   - dedicated

--- a/docs/dedicated-windows-enshrouded.md
+++ b/docs/dedicated-windows-enshrouded.md
@@ -1,7 +1,7 @@
 ---
 id: dedicated-windows-enshrouded
 title: "Dedicated Server: Enshrouded Dedicated Server Setup"
-description: Information about setting up an Enshrouded Dedicated Server on a Dedicated Server - ZAP-Hosting.com documentation
+description: Information about setting up an Enshrouded Dedicated Server on a Windows Dedicated Server from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: Enshrouded
 services:
   - dedicated

--- a/docs/dedicated-windows-enshrouded.md
+++ b/docs/dedicated-windows-enshrouded.md
@@ -1,6 +1,6 @@
 ---
 id: dedicated-windows-enshrouded
-title: "Dedicated Server: Enshrouded Dedicated Server Setup"
+title: "Dedicated Server: Enshrouded Dedicated Server Windows Setup"
 description: Information about setting up an Enshrouded Dedicated Server on a Windows Dedicated Server from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: Enshrouded
 services:

--- a/docs/dedicated-windows-foundry.md
+++ b/docs/dedicated-windows-foundry.md
@@ -1,6 +1,6 @@
 ---
 id: dedicated-windows-foundry
-title: "Dedicated Server: Foundry Dedicated Server Setup"
+title: "Dedicated Server: Foundry Dedicated Server Windows Setup"
 description: Information about setting up a Foundry Dedicated Server on a Windows Dedicated Server from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: Foundry
 services:

--- a/docs/dedicated-windows-foundry.md
+++ b/docs/dedicated-windows-foundry.md
@@ -1,7 +1,7 @@
 ---
 id: dedicated-windows-foundry
 title: "Dedicated Server: Foundry Dedicated Server Setup"
-description: Information about setting up a Foundry Dedicated Server on a Dedicated Server - ZAP-Hosting.com documentation
+description: Information about setting up a Foundry Dedicated Server on a Windows Dedicated Server from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: Foundry
 services:
   - dedicated

--- a/docs/dedicated-windows-fs-19.md
+++ b/docs/dedicated-windows-fs-19.md
@@ -1,6 +1,6 @@
 ---
 id: dedicated-windows-fs-19
-title: "Dedicated Server: Farming Simulator 2019 Dedicated Server Setup"
+title: "Dedicated Server: Farming Simulator 2019 Dedicated Server Windows Setup"
 description: Information about setting up a Farming Simulator 2019 Dedicated Server on a Windows Dedicated Server from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: Farming Simulator 2019
 services:

--- a/docs/dedicated-windows-fs-19.md
+++ b/docs/dedicated-windows-fs-19.md
@@ -1,7 +1,7 @@
 ---
 id: dedicated-windows-fs-19
 title: "Dedicated Server: Farming Simulator 2019 Dedicated Server Setup"
-description: Information on how to install and set up a Farming Simulator Dedicated Server 2019 on your Windows Dedicated Server from ZAP-Hosting - ZAP-Hosting.com documentation
+description: Information about setting up a Farming Simulator 2019 Dedicated Server on a Windows Dedicated Server from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: Farming Simulator 2019
 services:
   - dedicated

--- a/docs/dedicated-windows-fs-22-epic.md
+++ b/docs/dedicated-windows-fs-22-epic.md
@@ -1,6 +1,6 @@
 ---
 id: dedicated-windows-fs-22-epic
-title: "Dedicated Server: Farming Simulator 2022 (Epic Games) Dedicated Server Setup"
+title: "Dedicated Server: Farming Simulator 2022 (Epic Games) Dedicated Server Windows Setup"
 description: Information about setting up a Farming Simulator 2022 Dedicated Server (Epic Games version) on a Windows Dedicated Server from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: Farming Simulator 2022 (Epic Games)
 services:

--- a/docs/dedicated-windows-fs-22-epic.md
+++ b/docs/dedicated-windows-fs-22-epic.md
@@ -1,7 +1,7 @@
 ---
 id: dedicated-windows-fs-22-epic
 title: "Dedicated Server: Farming Simulator 2022 (Epic Games) Dedicated Server Setup"
-description: Information on how to install and set up a Farming Simulator 2022 dedicated server for the Epic Games version on your Windows Dedicated Server from ZAP-Hosting - ZAP-Hosting.com documentation
+description: Information about setting up a Farming Simulator 2022 Dedicated Server (Epic Games version) on a Windows Dedicated Server from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: Farming Simulator 2022 (Epic Games)
 services:
   - dedicated

--- a/docs/dedicated-windows-fs-22.md
+++ b/docs/dedicated-windows-fs-22.md
@@ -1,6 +1,6 @@
 ---
 id: dedicated-windows-fs-22
-title: "Dedicated Server: Farming Simulator 2022 Dedicated Server Setup"
+title: "Dedicated Server: Farming Simulator 2022 Dedicated Server Windows Setup"
 description: Information about setting up a Farming Simulator 2022 Dedicated Server on a Windows Dedicated Server from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: Farming Simulator 2022
 services:

--- a/docs/dedicated-windows-fs-22.md
+++ b/docs/dedicated-windows-fs-22.md
@@ -1,7 +1,7 @@
 ---
 id: dedicated-windows-fs-22
 title: "Dedicated Server: Farming Simulator 2022 Dedicated Server Setup"
-description: Information on how to install and set up a Farming Simulator Dedicated Server 2022 on your Windows Dedicated Server from ZAP-Hosting - ZAP-Hosting.com documentation
+description: Information about setting up a Farming Simulator 2022 Dedicated Server on a Windows Dedicated Server from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: Farming Simulator 2022
 services:
   - dedicated

--- a/docs/dedicated-windows-mythofempires.md
+++ b/docs/dedicated-windows-mythofempires.md
@@ -1,7 +1,7 @@
 ---
 id: dedicated-windows-mythofempires
 title: "Dedicated Server: Myth of Empires Dedicated Server Setup"
-description: Information about setting up a Myth of Empires Dedicated Server on a Dedicated Server - ZAP-Hosting.com documentation
+description: Information about setting up a Myth of Empires Dedicated Server on a Windows Dedicated Server from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: MOE Dedicated Server Setup
 services:
   - dedicated

--- a/docs/dedicated-windows-mythofempires.md
+++ b/docs/dedicated-windows-mythofempires.md
@@ -1,6 +1,6 @@
 ---
 id: dedicated-windows-mythofempires
-title: "Dedicated Server: Myth of Empires Dedicated Server Setup"
+title: "Dedicated Server: Myth of Empires Dedicated Server Windows Setup"
 description: Information about setting up a Myth of Empires Dedicated Server on a Windows Dedicated Server from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: MOE Dedicated Server Setup
 services:

--- a/docs/dedicated-windows-palworld.md
+++ b/docs/dedicated-windows-palworld.md
@@ -1,6 +1,6 @@
 ---
 id: dedicated-windows-palworld
-title: "Dedicated Server: Palworld Dedicated Server Setup"
+title: "Dedicated Server: Palworld Dedicated Server Windows Setup"
 description: Information about setting up a Palworld Dedicated Server on a Windows Dedicated Server from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: Palworld
 services:

--- a/docs/dedicated-windows-palworld.md
+++ b/docs/dedicated-windows-palworld.md
@@ -1,7 +1,7 @@
 ---
 id: dedicated-windows-palworld
 title: "Dedicated Server: Palworld Dedicated Server Setup"
-description: Information about setting up a Palworld Dedicated Server on a Dedicated Server - ZAP-Hosting.com documentation
+description: Information about setting up a Palworld Dedicated Server on a Windows Dedicated Server from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: Palworld
 services:
   - dedicated

--- a/docs/dedicated-windows-satisfactory.md
+++ b/docs/dedicated-windows-satisfactory.md
@@ -1,7 +1,7 @@
 ---
 id: dedicated-windows-satisfactory
 title: "Dedicated Server: Satisfactory Dedicated Server Setup"
-description: Information about setting up a Satisfactory Dedicated Server on a Dedicated Server - ZAP-Hosting.com documentation
+description: Information about setting up a Satisfactory Dedicated Server on a Windows Dedicated Server from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: Satisfactory
 services:
   - dedicated

--- a/docs/dedicated-windows-satisfactory.md
+++ b/docs/dedicated-windows-satisfactory.md
@@ -1,6 +1,6 @@
 ---
 id: dedicated-windows-satisfactory
-title: "Dedicated Server: Satisfactory Dedicated Server Setup"
+title: "Dedicated Server: Satisfactory Dedicated Server Windows Setup"
 description: Information about setting up a Satisfactory Dedicated Server on a Windows Dedicated Server from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: Satisfactory
 services:

--- a/docs/dedicated-windows-soulmask.md
+++ b/docs/dedicated-windows-soulmask.md
@@ -1,7 +1,7 @@
 ---
 id: dedicated-windows-soulmask
 title: "Dedicated Server: Soulmask Dedicated Server Setup"
-description: Information about setting up a Soulmask Dedicated Server on a Dedicated Server - ZAP-Hosting.com documentation
+description: Information about setting up a Soulmask Dedicated Server on a Windows Dedicated Server from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: Soulmask
 services:
   - dedicated

--- a/docs/dedicated-windows-soulmask.md
+++ b/docs/dedicated-windows-soulmask.md
@@ -1,6 +1,6 @@
 ---
 id: dedicated-windows-soulmask
-title: "Dedicated Server: Soulmask Dedicated Server Setup"
+title: "Dedicated Server: Soulmask Dedicated Server Windows Setup"
 description: Information about setting up a Soulmask Dedicated Server on a Windows Dedicated Server from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: Soulmask
 services:

--- a/docs/dedicated-windows-valheim.md
+++ b/docs/dedicated-windows-valheim.md
@@ -1,7 +1,7 @@
 ---
 id: dedicated-windows-valheim
 title: "Dedicated Server: Valheim Dedicated Server Setup"
-description: Information about setting up a Valheim Dedicated Server on a Dedicated Server - ZAP-Hosting.com documentation
+description: Information about setting up a Valheim Dedicated Server on a Windows Dedicated Server from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: Valheim
 services:
   - dedicated

--- a/docs/dedicated-windows-valheim.md
+++ b/docs/dedicated-windows-valheim.md
@@ -1,6 +1,6 @@
 ---
 id: dedicated-windows-valheim
-title: "Dedicated Server: Valheim Dedicated Server Setup"
+title: "Dedicated Server: Valheim Dedicated Server Windows Setup"
 description: Information about setting up a Valheim Dedicated Server on a Windows Dedicated Server from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: Valheim
 services:

--- a/docs/dedicated-windows-vrising.md
+++ b/docs/dedicated-windows-vrising.md
@@ -1,6 +1,6 @@
 ---
 id: dedicated-windows-vrising
-title: "Dedicated Server: V-Rising Dedicated Server Setup"
+title: "Dedicated Server: V-Rising Dedicated Server Windows Setup"
 description: Information about setting up a V-Rising Dedicated Server on a Windows Dedicated Server from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: V-Rising
 services:

--- a/docs/dedicated-windows-vrising.md
+++ b/docs/dedicated-windows-vrising.md
@@ -1,7 +1,7 @@
 ---
 id: dedicated-windows-vrising
 title: "Dedicated Server: V-Rising Dedicated Server Setup"
-description: Information on how to install and set up a V-Rising Server on your Dedicated Server from ZAP-Hosting - ZAP-Hosting.com documentation
+description: Information about setting up a V-Rising Dedicated Server on a Windows Dedicated Server from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: V-Rising
 services:
   - dedicated

--- a/docs/palworld-server-modding.md
+++ b/docs/palworld-server-modding.md
@@ -27,7 +27,7 @@ ZAP-Hosting is not liable for any potential modifications/damage to your server 
 :::
 
 :::info
-We currently only support PAK mods (.PAK files). You will not be able to use any mods which require an executible file for security purposes.
+We currently only support PAK mods (.PAK files). You will not be able to use any mods which require an executable file for security purposes.
 :::
 
 

--- a/docs/vserver-linux-arksurvivalascended.md
+++ b/docs/vserver-linux-arksurvivalascended.md
@@ -1,0 +1,101 @@
+---
+id: vserver-linux-arksurvivalascended
+title: "VPS: ARK Survival Ascended Dedicated Server Setup"
+description: Information about setting up an ARK Survival Ascended Dedicated Server on a Linux VPS from ZAP-Hosting - ZAP-Hosting.com documentation
+sidebar_label: ARK Survival Ascended
+services:
+  - vserver
+---
+
+import InlineVoucher from '@site/src/components/InlineVoucher';
+
+## Introduction
+Do you have a Linux VPS or root server and you want to install the ARK: Survival Ascended Dedicated server service on it? You are in the right place. In this guide, we will explain the step by step process of installing this service on your Linux server through the use of SteamCMD. We will be using Ubuntu in the examples, but the process should be very similar for other distributions.
+
+<InlineVoucher />
+
+## Preparation
+
+To begin with, connect to your VPS or root server via SSH. Use our [SSH Initial Access](vserver-linux-ssh.md) guide if you need help doing this.
+
+You will also have to complete a first-time setup for SteamCMD if this is your first time using this on your Linux server. Please use our [SteamCMD Linux Setup](vserver-linux-steamcmd.md) guide and ensure SteamCMD is fully setup before proceeding.
+
+### Installing Wine
+
+Currently, ARK: Survival Ascended does not have a native Linux-based server build, which means that there is an extra preparation step necessary to run the Windows server build on Linux. To resolve this, you will have to install the latest version of Wine which is a compatibility layer to allow Windows-native apps to run on Linux.
+
+Firstly, ensure that the `/etc/apt/keyrings/` directory exists, as this is necessary for Wine.
+```
+sudo mkdir -pm755 /etc/apt/keyrings
+```
+
+The next step is to download and store the Wine GPG key into this directory which verifies that the package is authentic.
+```
+sudo wget -O /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key
+```
+
+You will also have to save the sources list for WineHQ which can be done with the following pre-written source file:
+```
+sudo wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/dists/$(lsb_release -cs)/winehq-$(lsb_release -cs).sources
+```
+
+Run the update command again to ensure that your package changes are read and installed.
+```
+sudo apt update
+```
+
+Now you can download the latest version of Wine.
+```
+sudo apt install --install-recommends winehq-staging
+```
+
+Finally, you need to install a few extra packages to ensure Wine works well with the ARK: Survival Ascended server by running the following command.
+```
+sudo apt install cabextract winbind screen xvfb
+```
+
+You have successfully installed the Wine comaptibility layer, which will allow you to run ARK: Survival Ascended's Windows server build on your Linux server. Proceed with the installation.
+
+## Installation
+
+Begin by logging in to your `steam` user and heading over to the root `home/steam` user directory to keep things organised.
+```
+sudo -u steam -s
+cd ~
+```
+
+When logged in, you can start the installation process using the following command to easily start the installation through the use of SteamCMD directly to your `steam` user.
+```
+steamcmd +force_install_dir '/home/steam/ARK-SA-Server' +login anonymous +app_update 2430930 validate +quit
+```
+
+Please be patient as the download completes, it can take some time for games with larger sizes. Once successful, you will see a success message appear confirming this.
+
+## Configuration
+
+By this stage, you have finished the setup for your ARK: Survival Ascended server. You can perform further server configuration through a configuration file found within the directory of your server.
+
+You will be able to adjust all configuration parameters by accessing and editing the **GameUserSettings.ini** configuration file found within the Saved folder.
+
+```
+nano /home/steam/ARK-SA-Server/ShooterGame/Saved/Config/WindowsServer/GameUserSettings.ini
+```
+
+See our [ARK: Survival Ascended Server Configuration guide](ark-configuration.md) to view all of the available options and what they each do.
+
+## Starting & Connecting to your server
+
+Now it is time to start your server. Head over to the main game directory and run the **ArkAscendedServer.exe** executable file using the command below. Ensure that you add the **xvfb-run** and **wine** commands to run it through the Wine compatibility layer.
+```
+xvfb-run wine /home/steam/ARK-SA-Server/ShooterGame/Binaries/Win64/ArkAscendedServer.exe TheIsland_WP?listen
+```
+
+:::info
+Unfortunately due to a lack of support, you cannot run the Anti-Cheat Battleye version of the server on Linux. This is because the Anti-Cheat is not compatible at all.
+:::
+
+You should now see logs appear in your command prompt which signals that the start up was successful. Please note that first time start up could take some time as everything is setup. Alternatively, you will be able to connect directly by using the bottom search bar on the server list and searching for: `[your_ip_address]:7777`.
+
+## Conclusion
+
+Congratulations, you have successfully installed and configurated the ARK: Survival Ascended server on your VPS! If you have any further questions or problems, please contact our support team, who are available to help you every day! 

--- a/docs/vserver-linux-arksurvivalascended.md
+++ b/docs/vserver-linux-arksurvivalascended.md
@@ -72,4 +72,6 @@ You should now see logs appear in your command prompt which signals that the sta
 
 ## Conclusion
 
-Congratulations, you have successfully installed and configurated the ARK: Survival Ascended server on your VPS! If you have any further questions or problems, please contact our support team, who are available to help you every day! 
+Congratulations, you have successfully installed and configurated the ARK: Survival Ascended server on your VPS! As a next step, we recommend looking over our [Setup Linux Service](vserver-linux-create-gameservice.md) guide, which covers setting up your new dedicated game server as a service. This provides various benefits including automatic server launching on boot, automatic server updates, easy management and access to logs, plus much more!
+
+If you have any further questions or problems, please contact our support team, who are available to help you every day!

--- a/docs/vserver-linux-arksurvivalascended.md
+++ b/docs/vserver-linux-arksurvivalascended.md
@@ -30,42 +30,6 @@ ARK: Survival Ascended currently does not offer a native Linux-based server buil
 You have to complete a one-time installation of the **Wine** compatibility layer if this is your first time using this on your Linux server. Please use our quick [Wine Compatibility Layer Setup](vserver-linux-wine.md) guide to set this up before proceeding.
 :::
 
-### Installing Wine
-
-Currently, ARK: Survival Ascended does not have a native Linux-based server build, which means that there is an extra preparation step necessary to run the Windows server build on Linux. To resolve this, you will have to install the latest version of Wine which is a compatibility layer to allow Windows-native apps to run on Linux.
-
-Firstly, ensure that the `/etc/apt/keyrings/` directory exists, as this is necessary for Wine.
-```
-sudo mkdir -pm755 /etc/apt/keyrings
-```
-
-The next step is to download and store the Wine GPG key into this directory which verifies that the package is authentic.
-```
-sudo wget -O /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key
-```
-
-You will also have to save the sources list for WineHQ which can be done with the following pre-written source file:
-```
-sudo wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/dists/$(lsb_release -cs)/winehq-$(lsb_release -cs).sources
-```
-
-Run the update command again to ensure that your package changes are read and installed.
-```
-sudo apt update
-```
-
-Now you can download the latest version of Wine.
-```
-sudo apt install --install-recommends winehq-staging
-```
-
-Finally, you need to install a few extra packages to ensure Wine works well with the ARK: Survival Ascended server by running the following command.
-```
-sudo apt install cabextract winbind screen xvfb
-```
-
-You have successfully installed the Wine comaptibility layer, which will allow you to run ARK: Survival Ascended's Windows server build on your Linux server. Proceed with the installation.
-
 ## Installation
 
 Begin by logging in to your `steam` user and heading over to the root `home/steam` user directory to keep things organised.

--- a/docs/vserver-linux-arksurvivalascended.md
+++ b/docs/vserver-linux-arksurvivalascended.md
@@ -20,6 +20,12 @@ To begin with, connect to your VPS or root server via SSH. Use our [SSH Initial 
 
 You will also have to complete a first-time setup for SteamCMD if this is your first time using this on your Linux server. Please use our [SteamCMD Linux Setup](vserver-linux-steamcmd.md) guide and ensure SteamCMD is fully setup before proceeding.
 
+:::info Wine Compatibility Layer
+ARK: Survival Ascended currently does not offer a native Linux-based server build, which means that there is an extra preparation step necessary to run the Windows server build on Linux.
+
+You have to complete a one-time installation of the **Wine** compatibility layer if this is your first time using this on your Linux server. Please use our quick [Wine Compatibility Layer Setup](vserver-linux-wine.md) guide to set this up before proceeding.
+:::
+
 ### Installing Wine
 
 Currently, ARK: Survival Ascended does not have a native Linux-based server build, which means that there is an extra preparation step necessary to run the Windows server build on Linux. To resolve this, you will have to install the latest version of Wine which is a compatibility layer to allow Windows-native apps to run on Linux.

--- a/docs/vserver-linux-create-gameservice.md
+++ b/docs/vserver-linux-create-gameservice.md
@@ -1,7 +1,7 @@
 ---
 id: vserver-linux-create-gameservice
-title: "VPS: Setup a Linux Service for your Dedicated Game Server"
-description: Information about setting up a Linux Service for your dedicated game server on a Linux VPS from ZAP-Hosting - ZAP-Hosting.com documentation
+title: "VPS: Setup your Dedicated Game Server as a Linux Service"
+description: Information about setting up your dedicated game server as a Linux Service on a Linux VPS from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: Setup Linux Service
 services:
   - vserver
@@ -11,7 +11,7 @@ import InlineVoucher from '@site/src/components/InlineVoucher';
 
 ## Introduction
 
-Services are an integral part of Linux and refers to a process or application that runs in the background, either being a pre-defined task or an event-based task. This provides various benefits including automatic server launching on boot, automatic server updates, easy management and access to logs, plus much more! In this guide, we will explore the process of creating a service for your dedicated game servers.
+Services are an integral part of Linux and refers to a process or application that runs in the background, either being a pre-defined task or an event-based task. This provides various benefits including automatic server launching on boot, automatic server updates, easy management and access to logs, plus much more! In this guide, we will explore the process of creating a service for your dedicated game server.
 
 <InlineVoucher />
 

--- a/docs/vserver-linux-createservice.md
+++ b/docs/vserver-linux-createservice.md
@@ -1,0 +1,120 @@
+---
+id: vserver-linux-create-gameservice
+title: "VPS: Setup a Linux Service for your Dedicated Game Server"
+description: Information about setting up a Linux Service for your dedicated game server on a Linux VPS from ZAP-Hosting - ZAP-Hosting.com documentation
+sidebar_label: Setup Linux Service
+services:
+  - vserver
+---
+
+import InlineVoucher from '@site/src/components/InlineVoucher';
+
+## Introduction
+
+Services are an integral part of Linux and refers to a process or application that runs in the background, either being a pre-defined task or an event-based task. This provides various benefits including automatic server launching on boot, automatic server updates, easy management and access to logs, plus much more! In this guide, we will explore the process of creating a service for your dedicated game servers.
+
+<InlineVoucher />
+
+## Preparation
+
+To begin with, connect to your VPS or root server via SSH. Use our [SSH Initial Access](vserver-linux-ssh.md) guide if you need help doing this.
+
+You should also follow one of our dedicated game server guides in this section to install and setup a game server on your Linux system. In this guide, we will use the [Palworld dedicated game server](vserver-linux-palworld.md) as an example, but the instructions can be adapted for all of our guides.
+
+## Creating a Service
+
+Begin by creating a new service file for the dedicated game server that you have setup. Replace `[your_game]` with your choice of name. We recommend using the game's name to keep things organised, thus we will use `palworld.service`.
+```
+sudo nano /etc/systemd/system/[your_game].service
+```
+
+## Setting up Service
+
+With the nano editor now open, copy the following core file contents which is a template service file that you can reuse.
+```
+[Unit]
+Description=[your_server] Server
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+User=steam
+Group=steam
+WorkingDirectory=/home/steam/[your_server_folder]
+ExecStartPre=/usr/games/steamcmd +force_install_dir '/home/steam/[your_server_folder]' +login anonymous +app_update [your_game_steamid] +quit
+ExecStart=/home/steam/[your_server_folder]/[your_path_to_start_file]
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Let's break down the file contents to help understand everything.
+- `Description`: This can be anything, useful to easily distinguish the purpose of the service.
+- `User`: Using our guides, you should have setup a separate `steam` user for use with SteamCMD. If not, this should be set to the user that should run the service.
+- `WorkingDirectory`: This is the path to the main directory which contains everything the service requires.
+- `ExecStartPre`: In this field, we essentially setup the same SteamCMD installation command as before, which will run every time the server is restarted to ensure it is up-to-date. You should copy this from the respective dedicated game server guide, or replace the values manually with the values of the game.
+- `ExecStart`: This field determines the pre-defined task that should run with the service. Once again, you should copy the path from the respective dedicated game server guide, or replace the values manually to navigate to the start file.
+
+:::important Wine Compatibility Layer
+For games that require the **Wine** compatibility layer to be able to run, you should include the **xvfb-run** and **wine** commands within the `ExecStart` parameter. As an example for V-Rising:
+```
+/usr/bin/xvfb-run wine /home/steam/V-Rising-Server/start_server.bat
+```
+
+Please also ensure that your `ExecStartPre` SteamCMD installation command also includes the `+@sSteamCmdForcePlatformType` parameter if necessary to force a platform version.
+:::
+
+With all the input values now adapted to your dedicated game server, you can save the file and quit nano by using `CTRL + X`, followed by `Y` to confirm and lastly `ENTER`.
+
+Using our Palworld example, our file would look like the following:
+```
+[Unit]
+Description=Palworld Server
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+User=steam
+Group=steam
+WorkingDirectory=/home/steam/Palworld-Server
+ExecStartPre=/usr/games/steamcmd +force_install_dir '/home/steam/Palworld-Server' +login anonymous +app_update 2394010 +quit
+ExecStart=/home/steam/Palworld-Server/PalServer.sh
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+```
+
+## Managing Service
+
+With your service file now created, you will need to enable it. With the `palworld.service` example, `[your_service]` is replaced with just `palworld`.
+```
+sudo systemctl enable [your_service]
+```
+
+:::tip
+If at any point you perform changes to your service file, make sure to run `systemctl daemon-reload` afterwards to ensure that the changes take effect.
+:::
+
+You can now start the server with the `systemctl start` command. Likewise, you can easily stop and restart the server with similar commands.
+```
+sudo systemctl start [your_service]
+sudo systemctl stop [your_service]
+sudo systemctl restart [your_service]
+```
+
+:::tip
+To view details about the service, you can use the `systemctl status` command. If you require logs for debugging purposes, you can use the `journalctl -u [your_service].service` command to view the latest logs from the service.
+:::
+
+Lastly, if you ever wish to stop the service from running on start up, simply disable it.
+```
+sudo systemctl disable [your_service]
+```
+
+## Conclusion
+
+You have now successfully setup a service for your dedicated game server. The server will now automatically start upon server boot.
+
+You have also learnt about the contents of the service file as well as how to manage the service using a variety of commands.

--- a/docs/vserver-linux-enshrouded.md
+++ b/docs/vserver-linux-enshrouded.md
@@ -67,4 +67,6 @@ You should now see many logs appear in your command prompt. If you see the `[Ses
 
 ## Conclusion
 
-Congratulations, you have successfully installed and configurated the Enshrouded server on your VPS! If you have any further questions or problems, please contact our support team, who are available to help you every day! 
+Congratulations, you have successfully installed and configurated the Enshrouded server on your VPS! As a next step, we recommend looking over our [Setup Linux Service](vserver-linux-create-gameservice.md) guide, which covers setting up your new dedicated game server as a service. This provides various benefits including automatic server launching on boot, automatic server updates, easy management and access to logs, plus much more!
+
+If you have any further questions or problems, please contact our support team, who are available to help you every day!

--- a/docs/vserver-linux-enshrouded.md
+++ b/docs/vserver-linux-enshrouded.md
@@ -58,9 +58,9 @@ See our [Enshrouded Server Configuration guide](enshrouded-configuration.md) to 
 
 ## Starting & Connecting to your server
 
-Now it is time to start your server. Head over to the main game directory and run the **enshrouded_server.exe** executable file using the command below. Ensure that you add the **wine64** command to run it through the Wine compatibility layer.
+Now it is time to start your server. Head over to the main game directory and run the **enshrouded_server.exe** executable file using the command below. Ensure that you add the **xvfb-run** and **wine** commands to run it through the Wine compatibility layer.
 ```
-wine64 /home/steam/Enshrouded-Server/enshrouded_server.exe
+xvfb-run wine /home/steam/Enshrouded-Server/enshrouded_server.exe
 ```
 
 You should now see many logs appear in your command prompt. If you see the `[Session] 'HostOnline' (up)!` log message, this signals that the start up was successful. You will be able to connect directly by adding the server details in the **Find Games** tab: `[your_ip_address]:15636`.

--- a/docs/vserver-linux-enshrouded.md
+++ b/docs/vserver-linux-enshrouded.md
@@ -1,0 +1,96 @@
+---
+id: vserver-linux-enshrouded
+title: "VPS: Enshrouded Dedicated Server Setup"
+description: Information about setting up an Enshrouded Dedicated Server on a Linux VPS from ZAP-Hosting - ZAP-Hosting.com documentation
+sidebar_label: Enshrouded
+services:
+  - vserver
+---
+
+import InlineVoucher from '@site/src/components/InlineVoucher';
+
+## Introduction
+Do you have a Linux VPS or root server and you want to install the Enshrouded Dedicated server service on it? You are in the right place. In this guide, we will explain the step by step process of installing this service on your Linux server through the use of SteamCMD. We will be using Ubuntu in the examples, but the process should be very similar for other distributions.
+
+<InlineVoucher />
+
+## Preparation
+
+To begin with, connect to your VPS or root server via SSH. Use our [SSH Initial Access](vserver-linux-ssh.md) guide if you need help doing this.
+
+You will also have to complete a first-time setup for SteamCMD if this is your first time using this on your Linux server. Please use our [SteamCMD Linux Setup](vserver-linux-steamcmd.md) guide and ensure SteamCMD is fully setup before proceeding.
+
+### Installing Wine
+
+Currently, Enshrouded does not have a native Linux-based server build, which means that there is an extra preparation step necessary to run the Windows server build on Linux. To resolve this, you will have to install the latest version of Wine which is a compatibility layer to allow Windows-native apps to run on Linux.
+
+Firstly, ensure that the `/etc/apt/keyrings/` directory exists, as this is necessary for Wine.
+```
+sudo mkdir -pm755 /etc/apt/keyrings
+```
+
+The next step is to download and store the Wine GPG key into this directory which verifies that the package is authentic.
+```
+sudo wget -O /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key
+```
+
+You will also have to save the sources list for WineHQ which can be done with the following pre-written source file:
+```
+sudo wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/dists/$(lsb_release -cs)/winehq-$(lsb_release -cs).sources
+```
+
+Run the update command again to ensure that your package changes are read and installed.
+```
+sudo apt update
+```
+
+Now you can download the latest version of Wine.
+```
+sudo apt install --install-recommends winehq-staging
+```
+
+Finally, you need to install a few extra packages to ensure Wine works well with the Enshrouded server by running the following command.
+```
+sudo apt install cabextract winbind screen xvfb
+```
+
+You have successfully installed the Wine comaptibility layer, which will allow you to run Enshrouded's Windows server build on your Linux server. Proceed with the installation.
+
+## Installation
+
+Begin by logging in to your `steam` user and heading over to the root `home/steam` user directory to keep things organised.
+```
+sudo -u steam -s
+cd ~
+```
+
+When logged in, you can start the installation process using the following command to easily start the installation through the use of SteamCMD directly to your `steam` user. By using the `+@sSteamCmdForcePlatformType windows` parameter, you forcefully ensure that the Windows binaries are installed.
+```
+steamcmd +@sSteamCmdForcePlatformType windows +force_install_dir '/home/steam/Enshrouded-Server' +login anonymous +app_update 2278520 validate +quit
+```
+
+Please be patient as the download completes, it can take some time for games with larger sizes. Once successful, you will see a success message appear confirming this.
+
+## Configuration
+
+By this stage, you have finished the setup for your Enshrouded server. You can perform further server configuration through a configuration file found within the directory of your server.
+
+You will be able to adjust all configuration parameters by accessing and editing the **enshrouded_server.json** configuration file found in the root server directory.
+```
+nano /home/steam/Enshrouded-Server/enshrouded_server.json
+```
+
+See our [Enshrouded Server Configuration guide](enshrouded-configuration.md) to view all of the available server options and what they each do.
+
+## Starting & Connecting to your server
+
+Now it is time to start your server. Head over to the main game directory and run the **enshrouded_server.exe** executable file using the command below. Ensure that you add the **wine64** command to run it through the Wine compatibility layer.
+```
+wine64 /home/steam/Enshrouded-Server/enshrouded_server.exe
+```
+
+You should now see many logs appear in your command prompt. If you see the `[Session] 'HostOnline' (up)!` log message, this signals that the start up was successful. You will be able to connect directly by adding the server details in the **Find Games** tab: `[your_ip_address]:15636`.
+
+## Conclusion
+
+Congratulations, you have successfully installed and configurated the Enshrouded server on your VPS! If you have any further questions or problems, please contact our support team, who are available to help you every day! 

--- a/docs/vserver-linux-enshrouded.md
+++ b/docs/vserver-linux-enshrouded.md
@@ -20,41 +20,11 @@ To begin with, connect to your VPS or root server via SSH. Use our [SSH Initial 
 
 You will also have to complete a first-time setup for SteamCMD if this is your first time using this on your Linux server. Please use our [SteamCMD Linux Setup](vserver-linux-steamcmd.md) guide and ensure SteamCMD is fully setup before proceeding.
 
-### Installing Wine
+:::info Wine Compatibility Layer
+Enshrouded currently does not offer a native Linux-based server build, which means that there is an extra preparation step necessary to run the Windows server build on Linux.
 
-Currently, Enshrouded does not have a native Linux-based server build, which means that there is an extra preparation step necessary to run the Windows server build on Linux. To resolve this, you will have to install the latest version of Wine which is a compatibility layer to allow Windows-native apps to run on Linux.
-
-Firstly, ensure that the `/etc/apt/keyrings/` directory exists, as this is necessary for Wine.
-```
-sudo mkdir -pm755 /etc/apt/keyrings
-```
-
-The next step is to download and store the Wine GPG key into this directory which verifies that the package is authentic.
-```
-sudo wget -O /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key
-```
-
-You will also have to save the sources list for WineHQ which can be done with the following pre-written source file:
-```
-sudo wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/dists/$(lsb_release -cs)/winehq-$(lsb_release -cs).sources
-```
-
-Run the update command again to ensure that your package changes are read and installed.
-```
-sudo apt update
-```
-
-Now you can download the latest version of Wine.
-```
-sudo apt install --install-recommends winehq-staging
-```
-
-Finally, you need to install a few extra packages to ensure Wine works well with the Enshrouded server by running the following command.
-```
-sudo apt install cabextract winbind screen xvfb
-```
-
-You have successfully installed the Wine comaptibility layer, which will allow you to run Enshrouded's Windows server build on your Linux server. Proceed with the installation.
+You have to complete a one-time installation of the **Wine** compatibility layer if this is your first time using this on your Linux server. Please use our quick [Wine Compatibility Layer Setup](vserver-linux-wine.md) guide to set this up before proceeding.
+:::
 
 ## Installation
 

--- a/docs/vserver-linux-foundry.md
+++ b/docs/vserver-linux-foundry.md
@@ -1,0 +1,96 @@
+---
+id: vserver-linux-foundry
+title: "VPS: Foundry Dedicated Server Setup"
+description: Information about setting up an Foundry Dedicated Server on a Linux VPS from ZAP-Hosting - ZAP-Hosting.com documentation
+sidebar_label: Foundry
+services:
+  - vserver
+---
+
+import InlineVoucher from '@site/src/components/InlineVoucher';
+
+## Introduction
+Do you have a Linux VPS or root server and you want to install the Foundry Dedicated server service on it? You are in the right place. In this guide, we will explain the step by step process of installing this service on your Linux server through the use of SteamCMD. We will be using Ubuntu in the examples, but the process should be very similar for other distributions.
+
+<InlineVoucher />
+
+## Preparation
+
+To begin with, connect to your VPS or root server via SSH. Use our [SSH Initial Access](vserver-linux-ssh.md) guide if you need help doing this.
+
+You will also have to complete a first-time setup for SteamCMD if this is your first time using this on your Linux server. Please use our [SteamCMD Linux Setup](vserver-linux-steamcmd.md) guide and ensure SteamCMD is fully setup before proceeding.
+
+### Installing Wine
+
+Currently, Foundry does not have a native Linux-based server build, which means that there is an extra preparation step necessary to run the Windows server build on Linux. To resolve this, you will have to install the latest version of Wine which is a compatibility layer to allow Windows-native apps to run on Linux.
+
+Firstly, ensure that the `/etc/apt/keyrings/` directory exists, as this is necessary for Wine.
+```
+sudo mkdir -pm755 /etc/apt/keyrings
+```
+
+The next step is to download and store the Wine GPG key into this directory which verifies that the package is authentic.
+```
+sudo wget -O /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key
+```
+
+You will also have to save the sources list for WineHQ which can be done with the following pre-written source file:
+```
+sudo wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/dists/$(lsb_release -cs)/winehq-$(lsb_release -cs).sources
+```
+
+Run the update command again to ensure that your package changes are read and installed.
+```
+sudo apt update
+```
+
+Now you can download the latest version of Wine.
+```
+sudo apt install --install-recommends winehq-staging
+```
+
+Finally, you need to install a few extra packages to ensure Wine works well with the Foundry server by running the following command.
+```
+sudo apt install cabextract winbind screen xvfb
+```
+
+You have successfully installed the Wine comaptibility layer, which will allow you to run Foundry's Windows server build on your Linux server. Proceed with the installation.
+
+## Installation
+
+Begin by logging in to your `steam` user and heading over to the root `home/steam` user directory to keep things organised.
+```
+sudo -u steam -s
+cd ~
+```
+
+When logged in, you can start the installation process using the following command to easily start the installation through the use of SteamCMD directly to your `steam` user. By using the `+@sSteamCmdForcePlatformType windows` parameter, you forcefully ensure that the Windows binaries are installed.
+```
+steamcmd +@sSteamCmdForcePlatformType windows +force_install_dir '/home/steam/Foundry-Server' +login anonymous +app_update 2915550 validate +quit
+```
+
+Please be patient as the download completes, it can take some time for games with larger sizes. Once successful, you will see a success message appear confirming this.
+
+## Configuration
+
+By this stage, you have finished the setup for your Foundry server. You can perform further server configuration through a configuration file found within the directory of your server.
+
+You will be able to adjust all configuration parameters by accessing and editing the **app.cfg** configuration file found in the root server directory.
+```
+nano /home/steam/Foundry-Server/app.cfg
+```
+
+See our [Foundry Server Configuration guide](foundry-configuration.md) to view all of the available options and what they each do.
+
+## Starting & Connecting to your server
+
+Now it is time to start your server. Head over to the main game directory and run the **FoundryDedicatedServerLauncher.exe** executable file using the command below. Ensure that you add the **xvfb-run** and **wine** commands to run it through the Wine compatibility layer.
+```
+xvfb-run wine /home/steam/Foundry-Server/FoundryDedicatedServer.exe
+```
+
+You should now see logs appear in your command prompt which signals that the start up was successful. If everthing occurs as expected, your server will be visible in the server list. Alternatively, you will be able to connect directly by using the bottom search bar on the server list and searching for: `[your_ip_address]:3724`.
+
+## Conclusion
+
+Congratulations, you have successfully installed and configurated the Foundry server on your VPS! If you have any further questions or problems, please contact our support team, who are available to help you every day! 

--- a/docs/vserver-linux-foundry.md
+++ b/docs/vserver-linux-foundry.md
@@ -67,4 +67,6 @@ You should now see logs appear in your command prompt which signals that the sta
 
 ## Conclusion
 
-Congratulations, you have successfully installed and configurated the Foundry server on your VPS! If you have any further questions or problems, please contact our support team, who are available to help you every day! 
+Congratulations, you have successfully installed and configurated the Foundry server on your VPS! As a next step, we recommend looking over our [Setup Linux Service](vserver-linux-create-gameservice.md) guide, which covers setting up your new dedicated game server as a service. This provides various benefits including automatic server launching on boot, automatic server updates, easy management and access to logs, plus much more!
+
+If you have any further questions or problems, please contact our support team, who are available to help you every day!

--- a/docs/vserver-linux-foundry.md
+++ b/docs/vserver-linux-foundry.md
@@ -20,41 +20,11 @@ To begin with, connect to your VPS or root server via SSH. Use our [SSH Initial 
 
 You will also have to complete a first-time setup for SteamCMD if this is your first time using this on your Linux server. Please use our [SteamCMD Linux Setup](vserver-linux-steamcmd.md) guide and ensure SteamCMD is fully setup before proceeding.
 
-### Installing Wine
+:::info Wine Compatibility Layer
+Foundry currently does not offer a native Linux-based server build, which means that there is an extra preparation step necessary to run the Windows server build on Linux.
 
-Currently, Foundry does not have a native Linux-based server build, which means that there is an extra preparation step necessary to run the Windows server build on Linux. To resolve this, you will have to install the latest version of Wine which is a compatibility layer to allow Windows-native apps to run on Linux.
-
-Firstly, ensure that the `/etc/apt/keyrings/` directory exists, as this is necessary for Wine.
-```
-sudo mkdir -pm755 /etc/apt/keyrings
-```
-
-The next step is to download and store the Wine GPG key into this directory which verifies that the package is authentic.
-```
-sudo wget -O /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key
-```
-
-You will also have to save the sources list for WineHQ which can be done with the following pre-written source file:
-```
-sudo wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/dists/$(lsb_release -cs)/winehq-$(lsb_release -cs).sources
-```
-
-Run the update command again to ensure that your package changes are read and installed.
-```
-sudo apt update
-```
-
-Now you can download the latest version of Wine.
-```
-sudo apt install --install-recommends winehq-staging
-```
-
-Finally, you need to install a few extra packages to ensure Wine works well with the Foundry server by running the following command.
-```
-sudo apt install cabextract winbind screen xvfb
-```
-
-You have successfully installed the Wine comaptibility layer, which will allow you to run Foundry's Windows server build on your Linux server. Proceed with the installation.
+You have to complete a one-time installation of the **Wine** compatibility layer if this is your first time using this on your Linux server. Please use our quick [Wine Compatibility Layer Setup](vserver-linux-wine.md) guide to set this up before proceeding.
+:::
 
 ## Installation
 

--- a/docs/vserver-linux-mythofempires.md
+++ b/docs/vserver-linux-mythofempires.md
@@ -20,41 +20,11 @@ To begin with, connect to your VPS or root server via SSH. Use our [SSH Initial 
 
 You will also have to complete a first-time setup for SteamCMD if this is your first time using this on your Linux server. Please use our [SteamCMD Linux Setup](vserver-linux-steamcmd.md) guide and ensure SteamCMD is fully setup before proceeding.
 
-### Installing Wine
+:::info Wine Compatibility Layer
+Myth of Empires currently does not offer a native Linux-based server build, which means that there is an extra preparation step necessary to run the Windows server build on Linux.
 
-Currently, Myth of Empires does not have a native Linux-based server build, which means that there is an extra preparation step necessary to run the Windows server build on Linux. To resolve this, you will have to install the latest version of Wine which is a compatibility layer to allow Windows-native apps to run on Linux.
-
-Firstly, ensure that the `/etc/apt/keyrings/` directory exists, as this is necessary for Wine.
-```
-sudo mkdir -pm755 /etc/apt/keyrings
-```
-
-The next step is to download and store the Wine GPG key into this directory which verifies that the package is authentic.
-```
-sudo wget -O /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key
-```
-
-You will also have to save the sources list for WineHQ which can be done with the following pre-written source file:
-```
-sudo wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/dists/$(lsb_release -cs)/winehq-$(lsb_release -cs).sources
-```
-
-Run the update command again to ensure that your package changes are read and installed.
-```
-sudo apt update
-```
-
-Now you can download the latest version of Wine.
-```
-sudo apt install --install-recommends winehq-staging
-```
-
-Finally, you need to install a few extra packages to ensure Wine works well with the Myth of Empires server by running the following command.
-```
-sudo apt install cabextract winbind screen xvfb
-```
-
-You have successfully installed the Wine comaptibility layer, which will allow you to run Myth of Empires's Windows server build on your Linux server. Proceed with the installation.
+You have to complete a one-time installation of the **Wine** compatibility layer if this is your first time using this on your Linux server. Please use our quick [Wine Compatibility Layer Setup](vserver-linux-wine.md) guide to set this up before proceeding.
+:::
 
 ## Installation
 

--- a/docs/vserver-linux-mythofempires.md
+++ b/docs/vserver-linux-mythofempires.md
@@ -69,4 +69,6 @@ You should now see logs appear in your command prompt which signals that the sta
 
 ## Conclusion
 
-Congratulations, you have successfully installed and configurated the Myth of Empires server on your VPS! If you have any further questions or problems, please contact our support team, who are available to help you every day! 
+Congratulations, you have successfully installed and configurated the Myth of Empires server on your VPS! As a next step, we recommend looking over our [Setup Linux Service](vserver-linux-create-gameservice.md) guide, which covers setting up your new dedicated game server as a service. This provides various benefits including automatic server launching on boot, automatic server updates, easy management and access to logs, plus much more!
+
+If you have any further questions or problems, please contact our support team, who are available to help you every day!

--- a/docs/vserver-linux-mythofempires.md
+++ b/docs/vserver-linux-mythofempires.md
@@ -1,0 +1,98 @@
+---
+id: vserver-linux-mythofempires
+title: "VPS: Myth of Empires Dedicated Server Setup"
+description: Information about setting up an Myth of Empires Dedicated Server on a Linux VPS from ZAP-Hosting - ZAP-Hosting.com documentation
+sidebar_label: Myth of Empires
+services:
+  - vserver
+---
+
+import InlineVoucher from '@site/src/components/InlineVoucher';
+
+## Introduction
+Do you have a Linux VPS or root server and you want to install the Myth of Empires Dedicated server service on it? You are in the right place. In this guide, we will explain the step by step process of installing this service on your Linux server through the use of SteamCMD. We will be using Ubuntu in the examples, but the process should be very similar for other distributions.
+
+<InlineVoucher />
+
+## Preparation
+
+To begin with, connect to your VPS or root server via SSH. Use our [SSH Initial Access](vserver-linux-ssh.md) guide if you need help doing this.
+
+You will also have to complete a first-time setup for SteamCMD if this is your first time using this on your Linux server. Please use our [SteamCMD Linux Setup](vserver-linux-steamcmd.md) guide and ensure SteamCMD is fully setup before proceeding.
+
+### Installing Wine
+
+Currently, Myth of Empires does not have a native Linux-based server build, which means that there is an extra preparation step necessary to run the Windows server build on Linux. To resolve this, you will have to install the latest version of Wine which is a compatibility layer to allow Windows-native apps to run on Linux.
+
+Firstly, ensure that the `/etc/apt/keyrings/` directory exists, as this is necessary for Wine.
+```
+sudo mkdir -pm755 /etc/apt/keyrings
+```
+
+The next step is to download and store the Wine GPG key into this directory which verifies that the package is authentic.
+```
+sudo wget -O /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key
+```
+
+You will also have to save the sources list for WineHQ which can be done with the following pre-written source file:
+```
+sudo wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/dists/$(lsb_release -cs)/winehq-$(lsb_release -cs).sources
+```
+
+Run the update command again to ensure that your package changes are read and installed.
+```
+sudo apt update
+```
+
+Now you can download the latest version of Wine.
+```
+sudo apt install --install-recommends winehq-staging
+```
+
+Finally, you need to install a few extra packages to ensure Wine works well with the Myth of Empires server by running the following command.
+```
+sudo apt install cabextract winbind screen xvfb
+```
+
+You have successfully installed the Wine comaptibility layer, which will allow you to run Myth of Empires's Windows server build on your Linux server. Proceed with the installation.
+
+## Installation
+
+Begin by logging in to your `steam` user and heading over to the root `home/steam` user directory to keep things organised.
+```
+sudo -u steam -s
+cd ~
+```
+
+When logged in, you can start the installation process using the following command to easily start the installation through the use of SteamCMD directly to your `steam` user. By using the `+@sSteamCmdForcePlatformType windows` parameter, you forcefully ensure that the Windows binaries are installed.
+```
+steamcmd +@sSteamCmdForcePlatformType windows +force_install_dir '/home/steam/MOE-Server' +login anonymous +app_update 1794810 validate +quit
+```
+
+Please be patient as the download completes, it can take some time for games with larger sizes. Once successful, you will see a success message appear confirming this.
+
+## Configuration
+
+By this stage, you have finished the setup for your Myth of Empires server. You can perform further server configuration through a variety of configuration files found within the directory of your server.
+
+You will be able to adjust all configuration parameters by accessing and editing configuration `.ini` files found within the Saved folder. Use the `ls` command to see what files there are.
+```
+cd /home/steam/MOE-Server/MOE/Saved/Config/WindowsServer
+```
+
+To edit a file, simply run `nano ./[filename].ini` to open the nano editor.
+
+See our [Myth of Empires Server Configuration guide](moe-configuration.md) to view all of the available server options and what they each do.
+
+## Starting & Connecting to your server
+
+Now it is time to start your server. Head over to the main game directory and run the **MOEServer.exe** executable file using the command below. Ensure that you add the **xvfb-run** and **wine** commands to run it through the Wine compatibility layer.
+```
+xvfb-run wine /home/steam/MOE-Server/MOE/Binaries/Win64/MOEServer.exe
+```
+
+You should now see logs appear in your command prompt which signals that the start up was successful. Please note that first time start up could take some time as everything is setup. You will be able to connect directly by searching for the server details in the **Custom Server** tab: `[your_ip_address]:15636`.
+
+## Conclusion
+
+Congratulations, you have successfully installed and configurated the Myth of Empires server on your VPS! If you have any further questions or problems, please contact our support team, who are available to help you every day! 

--- a/docs/vserver-linux-palworld.md
+++ b/docs/vserver-linux-palworld.md
@@ -66,4 +66,6 @@ You should now see logs appear in your command prompt, including a game version 
 
 ## Conclusion
 
-Congratulations, you have successfully installed and configurated the Palworld server on your VPS! If you have any further questions or problems, please contact our support team, who are available to help you every day! 
+Congratulations, you have successfully installed and configurated the Palworld server on your VPS! As a next step, we recommend looking over our [Setup Linux Service](vserver-linux-create-gameservice.md) guide, which covers setting up your new dedicated game server as a service. This provides various benefits including automatic server launching on boot, automatic server updates, easy management and access to logs, plus much more!
+
+If you have any further questions or problems, please contact our support team, who are available to help you every day!

--- a/docs/vserver-linux-palworld.md
+++ b/docs/vserver-linux-palworld.md
@@ -1,0 +1,65 @@
+---
+id: vserver-linux-palworld
+title: "VPS: Palworld Dedicated Server Setup"
+description: Information about setting up an Palworld Dedicated Server on a Linux VPS from ZAP-Hosting - ZAP-Hosting.com documentation
+sidebar_label: Palworld
+services:
+  - vserver
+---
+
+import InlineVoucher from '@site/src/components/InlineVoucher';
+
+## Introduction
+Do you have a Linux VPS or root server and you want to install the Palworld Dedicated server service on it? You are in the right place. In this guide, we will explain the step by step process of installing this service on your Linux server through the use of SteamCMD. We will be using Ubuntu in the examples, but the process should be very similar for other distributions.
+
+<InlineVoucher />
+
+## Preparation
+
+To begin with, connect to your VPS or root server via SSH. Use our [SSH Initial Access](vserver-linux-ssh.md) guide if you need help doing this.
+
+You will also have to complete a first-time setup for SteamCMD if this is your first time using this on your Linux server. Please use our [SteamCMD Linux Setup](vserver-linux-steamcmd.md) guide and ensure SteamCMD is fully setup before proceeding.
+
+## Installation
+
+Begin by logging in to your `steam` user and heading over to the root `home/steam` user directory to keep things organised.
+```
+sudo -u steam -s
+cd ~
+```
+
+When logged in, you can start the installation process using the following command to easily start the installation through the use of SteamCMD directly to your `steam` user.
+```
+steamcmd +force_install_dir '/home/steam/Palworld-Server' +login anonymous +app_update 2394010 validate +quit
+```
+
+Please be patient as the download completes, it can take some time for games with larger sizes. Once successful, you will see a success message appear confirming this.
+
+## Configuration
+
+By this stage, you have finished the setup for your Palworld server. You can perform further server configuration through a configuration file found within the directory of your server.
+
+You will need to create a copy of the default configuration file and add it to the saved folder before you can edit.
+```
+cp /home/steam/Palworld-Server/DefaultPalWorldSettings.ini /home/steam/Palworld-Server/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini
+```
+
+With the copy created, you can edit the core configuration parameters by opening the new **PalWorldSettings.ini** configuration file.
+```
+nano /home/steam/Palworld-Server/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini
+```
+
+See our [Palworld Server Configuration guide](palworld-configuration.md) to view all of the available options and what they each do.
+
+## Starting & Connecting to your server
+
+Now it is time to start your server. Head over to the main game directory and run the **PalServer.sh** shell file.
+```
+/home/steam/Palworld-Server/PalServer.sh
+```
+
+You should now see logs appear in your command prompt, including a game version log, which signals that the start up was successful. If everthing occurs as expected, your server will be visible in the server list. Alternatively, you will be able to connect directly by using the bottom search bar on the server list and searching for: `[your_ip_address]:8211`.
+
+## Conclusion
+
+Congratulations, you have successfully installed and configurated the Palworld server on your VPS! If you have any further questions or problems, please contact our support team, who are available to help you every day! 

--- a/docs/vserver-linux-satisfactory.md
+++ b/docs/vserver-linux-satisfactory.md
@@ -1,0 +1,59 @@
+---
+id: vserver-linux-satisfactory
+title: "VPS: Satisfactory Dedicated Server Setup"
+description: Information about setting up an Satisfactory Dedicated Server on a Linux VPS from ZAP-Hosting - ZAP-Hosting.com documentation
+sidebar_label: Satisfactory
+services:
+  - vserver
+---
+
+import InlineVoucher from '@site/src/components/InlineVoucher';
+
+## Introduction
+Do you have a Linux VPS or root server and you want to install the Satisfactory Dedicated server service on it? You are in the right place. In this guide, we will explain the step by step process of installing this service on your Linux server through the use of SteamCMD. We will be using Ubuntu in the examples, but the process should be very similar for other distributions.
+
+<InlineVoucher />
+
+## Preparation
+
+To begin with, connect to your VPS or root server via SSH. Use our [SSH Initial Access](vserver-linux-ssh.md) guide if you need help doing this.
+
+You will also have to complete a first-time setup for SteamCMD if this is your first time using this on your Linux server. Please use our [SteamCMD Linux Setup](vserver-linux-steamcmd.md) guide and ensure SteamCMD is fully setup before proceeding.
+
+## Installation
+
+Begin by logging in to your `steam` user and heading over to the root `home/steam` user directory to keep things organised.
+```
+sudo -u steam -s
+cd ~
+```
+
+When logged in, you can start the installation process using the following command to easily start the installation through the use of SteamCMD directly to your `steam` user.
+```
+steamcmd +force_install_dir '/home/steam/Satisfactory-Server' +login anonymous +app_update 1690800 validate +quit
+```
+
+Please be patient as the download completes, it can take some time for games with larger sizes. Once successful, you will see a success message appear confirming this.
+
+## Configuration
+
+By this stage, you have finished the setup for your Satisfactory server. You can perform further server configuration through a configuration files found within the directory of your server.
+
+You will be able to adjust all configuration parameters by accessing and editing the **Engine.ini** and **GameUserSettings.ini** configuration files found within the Saved folder.
+```
+nano /home/steam/Satisfactory-Server/FactoryGame/Saved/Config/LinuxServer/GameUserSettings.ini
+nano /home/steam/Satisfactory-Server/FactoryGame/Saved/Config/LinuxServer/Engine.ini
+```
+
+## Starting & Connecting to your server
+
+Now it is time to start your server. Head over to the main game directory and run the **FactoryServer.sh** shell file.
+```
+/home/steam/Satisfactory-Server/FactoryServer.sh
+```
+
+You should now see logs appear in your command prompt which signals that the start up was successful. Please note that first time start up could take some time as everything is setup. Alternatively, you will be able to connect directly by using the bottom search bar on the server list and searching for: `[your_ip_address]:15777`.
+
+## Conclusion
+
+Congratulations, you have successfully installed and configurated the Satisfactory server on your VPS! If you have any further questions or problems, please contact our support team, who are available to help you every day! 

--- a/docs/vserver-linux-satisfactory.md
+++ b/docs/vserver-linux-satisfactory.md
@@ -60,4 +60,6 @@ You should now see logs appear in your command prompt which signals that the sta
 
 ## Conclusion
 
-Congratulations, you have successfully installed and configurated the Satisfactory server on your VPS! If you have any further questions or problems, please contact our support team, who are available to help you every day! 
+Congratulations, you have successfully installed and configurated the Satisfactory server on your VPS! As a next step, we recommend looking over our [Setup Linux Service](vserver-linux-create-gameservice.md) guide, which covers setting up your new dedicated game server as a service. This provides various benefits including automatic server launching on boot, automatic server updates, easy management and access to logs, plus much more!
+
+If you have any further questions or problems, please contact our support team, who are available to help you every day!

--- a/docs/vserver-linux-soulmask.md
+++ b/docs/vserver-linux-soulmask.md
@@ -59,4 +59,6 @@ You should now see logs appear in your command prompt which signals that the sta
 
 ## Conclusion
 
-Congratulations, you have successfully installed and configurated the Soulmask server on your VPS! If you have any further questions or problems, please contact our support team, who are available to help you every day! 
+Congratulations, you have successfully installed and configurated the Soulmask server on your VPS! As a next step, we recommend looking over our [Setup Linux Service](vserver-linux-create-gameservice.md) guide, which covers setting up your new dedicated game server as a service. This provides various benefits including automatic server launching on boot, automatic server updates, easy management and access to logs, plus much more!
+
+If you have any further questions or problems, please contact our support team, who are available to help you every day!

--- a/docs/vserver-linux-soulmask.md
+++ b/docs/vserver-linux-soulmask.md
@@ -1,0 +1,58 @@
+---
+id: vserver-linux-soulmask
+title: "VPS: Soulmask Dedicated Server Setup"
+description: Information about setting up an Soulmask Dedicated Server on a Linux VPS from ZAP-Hosting - ZAP-Hosting.com documentation
+sidebar_label: Soulmask
+services:
+  - vserver
+---
+
+import InlineVoucher from '@site/src/components/InlineVoucher';
+
+## Introduction
+Do you have a Linux VPS or root server and you want to install the Soulmask Dedicated server service on it? You are in the right place. In this guide, we will explain the step by step process of installing this service on your Linux server through the use of SteamCMD. We will be using Ubuntu in the examples, but the process should be very similar for other distributions.
+
+<InlineVoucher />
+
+## Preparation
+
+To begin with, connect to your VPS or root server via SSH. Use our [SSH Initial Access](vserver-linux-ssh.md) guide if you need help doing this.
+
+You will also have to complete a first-time setup for SteamCMD if this is your first time using this on your Linux server. Please use our [SteamCMD Linux Setup](vserver-linux-steamcmd.md) guide and ensure SteamCMD is fully setup before proceeding.
+
+## Installation
+
+Begin by logging in to your `steam` user and heading over to the root `home/steam` user directory to keep things organised.
+```
+sudo -u steam -s
+cd ~
+```
+
+When logged in, you can start the installation process using the following command to easily start the installation through the use of SteamCMD directly to your `steam` user.
+```
+steamcmd +force_install_dir '/home/steam/Soulmask-Server' +login anonymous +app_update 3017300 validate +quit
+```
+
+Please be patient as the download completes, it can take some time for games with larger sizes. Once successful, you will see a success message appear confirming this.
+
+## Configuration
+
+By this stage, you have finished the setup for your Soulmask server. You can perform further server configuration through a configuration files found within the directory of your server.
+
+You will be able to adjust all configuration parameters by accessing and editing the **Engine.ini** configuration found within the Saved folder.
+```
+nano /home/steam/Soulmask-Server/Engine/Saved/Config/LinuxServer/Engine.ini
+```
+
+## Starting & Connecting to your server
+
+Now it is time to start your server. Head over to the main game directory and run the **StartServer.sh** executable file using the command below.
+```
+/home/steam/Soulmask-Server/StartServer.sh
+```
+
+You should now see logs appear in your command prompt which signals that the start up was successful. Please note that first time start up could take some time as everything is setup. Alternatively, you will be able to connect directly by using the bottom search bar on the server list and searching for: `[your_ip_address]:18888`.
+
+## Conclusion
+
+Congratulations, you have successfully installed and configurated the Soulmask server on your VPS! If you have any further questions or problems, please contact our support team, who are available to help you every day! 

--- a/docs/vserver-linux-steamcmd.md
+++ b/docs/vserver-linux-steamcmd.md
@@ -98,7 +98,7 @@ export PATH="/usr/games/:$PATH"
 
 Save the file and quit nano by using `CTRL + X`, followed by `Y` to confirm and lastly `ENTER`.
 
-### Conclusion
+## Conclusion
 
 You have now successfully setup the core SteamCMD functionality for your Linux server. You can now proceed with installing Steam content through the `steam` user.
 

--- a/docs/vserver-linux-steamcmd.md
+++ b/docs/vserver-linux-steamcmd.md
@@ -1,0 +1,105 @@
+---
+id: vserver-linux-steamcmd
+title: "VPS: SteamCMD Setup"
+description: Information about setting up SteamCMD on a Linux VPS from ZAP-Hosting - ZAP-Hosting.com documentation
+sidebar_label: Setup SteamCMD
+services:
+  - vserver
+---
+
+import InlineVoucher from '@site/src/components/InlineVoucher';
+
+## Introduction
+SteamCMD is an essential tool that is necessary for installing dedicated servers for a wide variety of games including Palworld, Enshrouded and more. In this guide, we will explore the first-time setup process for installing SteamCMD to your Linux server. We will be using Ubuntu in the examples, but the process should be very similar for other distributions.
+
+<InlineVoucher />
+
+## Preparation
+
+To begin with, connect to your VPS or root server via SSH. Use our [SSH Initial Access](vserver-linux-ssh.md) guide if you need help doing this.
+
+## Installing SteamCMD
+
+Once you have accessed your server, you will need to setup **SteamCMD** in order to be able to download the necessary dedicated server files. SteamCMD is the **command-line (CLI)** version of the Steam client and is the tool which allows you to easily download a range of Steam workshop and dedicated server files.
+
+As usual with Linux it is best to first update the system, by running the following based on the distro you use:
+```
+// Debian
+sudo apt-get update
+
+// Ubuntu
+sudo apt update
+
+// CentOS
+sudo yum update
+
+// OpenSUSE
+sudo zypper up
+
+// Fedora
+sudo dnf upgrade --refresh
+```
+
+Now you will need to install a few packages. These are broken down as following:
+
+- The **software-properties-common** package makes management of your distro and independent software sources easy.
+- SteamCMD is a 32-bit tool, therefore the **i386** architecture must be added so the appropriate software is installed to your system to support this.
+- Since SteamCMD is proprietary, this also means that you either need the **multiverse** or **non-free** package depending on your Linux Distro, as these are usually not included in the default repository.
+
+```
+sudo apt install software-properties-common
+sudo dpkg --add-architecture i386
+
+// Debian & Ubuntu
+sudo add-apt-repository multiverse
+
+// Other Non-Debian Distros
+sudo apt-add-repository non-free
+```
+
+Now run the update command to ensure that your package changes are read and thus installed to your system:
+```
+sudo apt update
+```
+
+Finally, you can install SteamCMD by running the following. A license agreement prompt may appear, which you can simply accept to continue.
+```
+sudo apt install steamcmd
+```
+
+:::tip
+You can verify that the SteamCMD installation was successful, by simply running `steamcmd`. Once loaded, the command prompt should show `Steam>`. You can run `quit` to exit this afterwards.
+:::
+
+With everything now prepared and installed, you can proceed with the next step which involves installing the dedicated server through the use of SteamCMD.
+
+## Creating User
+
+We highly recommend creating a separate user to use SteamCMD on. Running on the root user, as with most things, is not recommended for various reasons.
+
+Use the following command to create a user named `steam` with an optional password of your choice.
+
+```
+sudo useradd -m steam
+sudo passwd [your_password] # Optional Password
+```
+
+Once the user is created, you will need to adjust the `.bashrc` file to provide access to the `/usr/games` path where SteamCMD is located. This is done by adding an extra path environment variable.
+
+Open the file using nano editor by running:
+```
+sudo nano /home/steam/.bashrc
+```
+
+Now scroll down to the end of the file using your arrow keys and add the following path environment variable:
+```
+export PATH="/usr/games/:$PATH"
+```
+
+Save the file and quit nano by using `CTRL + X`, followed by `Y` to confirm and lastly `ENTER`.
+
+### Conclusion
+
+You have now successfully setup the core SteamCMD functionality for your Linux server. You can now proceed with installing Steam content through the `steam` user.
+
+We recommend checking out the other guides in this section which cover installing specific games through the use of SteamCMD, that you have now setup.

--- a/docs/vserver-linux-valheim.md
+++ b/docs/vserver-linux-valheim.md
@@ -70,4 +70,6 @@ Once installed, use the following command to launch the Windows version through 
 
 ## Conclusion
 
-Congratulations, you have successfully installed and configurated the Valheim server on your VPS! If you have any further questions or problems, please contact our support team, who are available to help you every day! 
+Congratulations, you have successfully installed and configurated the Valheim server on your VPS! As a next step, we recommend looking over our [Setup Linux Service](vserver-linux-create-gameservice.md) guide, which covers setting up your new dedicated game server as a service. This provides various benefits including automatic server launching on boot, automatic server updates, easy management and access to logs, plus much more!
+
+If you have any further questions or problems, please contact our support team, who are available to help you every day!

--- a/docs/vserver-linux-valheim.md
+++ b/docs/vserver-linux-valheim.md
@@ -56,7 +56,7 @@ You should now see logs appear in your command prompt which signals that the sta
 :::info
 If you cannot connect and receive `PlayFab` errors in console, you may need to disable crossplay support to resolve this as this is a current issue with the Linux version. To do so, run `nano /home/steam/Valheim-Server/start_server.sh` and remove the `-crossplay` flag.
 
-If you do require crossplay, an alternate solution is to instead install the Windows version and use Wine as a compatibility layer. See the **Installing Wine** section [on this example guide](vserver-linux-enshrouded.md) on how to do this. Then install the Valheim Windows server version via SteamCMD using:
+If you do require crossplay, an alternate solution is to instead install the Windows version and use **Wine** as a compatibility layer. Please use our quick [Wine Compatibility Layer Setup](vserver-linux-wine.md) guide to set this up. Once ready, you can install the Valheim Windows server version via SteamCMD using:
 ```
 steamcmd +@sSteamCmdForcePlatformType windows +force_install_dir '/home/steam/Valheim-Server' +login anonymous +app_update 896660 validate +quit
 ```

--- a/docs/vserver-linux-valheim.md
+++ b/docs/vserver-linux-valheim.md
@@ -1,0 +1,69 @@
+---
+id: vserver-linux-valheim
+title: "VPS: Valheim Dedicated Server Setup"
+description: Information about setting up an Valheim Dedicated Server on a Linux VPS from ZAP-Hosting - ZAP-Hosting.com documentation
+sidebar_label: Valheim
+services:
+  - vserver
+---
+
+import InlineVoucher from '@site/src/components/InlineVoucher';
+
+## Introduction
+Do you have a Linux VPS or root server and you want to install the Valheim Dedicated server service on it? You are in the right place. In this guide, we will explain the step by step process of installing this service on your Linux server through the use of SteamCMD. We will be using Ubuntu in the examples, but the process should be very similar for other distributions.
+
+<InlineVoucher />
+
+## Preparation
+
+To begin with, connect to your VPS or root server via SSH. Use our [SSH Initial Access](vserver-linux-ssh.md) guide if you need help doing this.
+
+You will also have to complete a first-time setup for SteamCMD if this is your first time using this on your Linux server. Please use our [SteamCMD Linux Setup](vserver-linux-steamcmd.md) guide and ensure SteamCMD is fully setup before proceeding.
+
+## Installation
+
+Begin by logging in to your `steam` user and heading over to the root `home/steam` user directory to keep things organised.
+```
+sudo -u steam -s
+cd ~
+```
+
+When logged in, you can start the installation process using the following command to easily start the installation through the use of SteamCMD directly to your `steam` user.
+```
+steamcmd +force_install_dir '/home/steam/Valheim-Server' +login anonymous +app_update 896660 validate +quit
+```
+
+Please be patient as the download completes, it can take some time for games with larger sizes. Once successful, you will see a success message appear confirming this.
+
+## Configuration
+
+By this stage, you have finished the setup for your Valheim server. You can perform further server configuration by directing editing the launch file.
+
+Head over to your root directory and open the `.sh` file. You can edit parameters here.
+```
+nano /home/steam/Valheim-Server/start_server.sh
+```
+
+## Starting & Connecting to your server
+
+Now it is time to start your server. Head over to the main game directory and run the **start_server.sh** shell file.
+```
+/home/steam/Valheim-Server/start_server.sh
+```
+
+You should now see logs appear in your command prompt which signals that the start up was successful. Please note that first time start up could take some time as everything is setup. Alternatively, you will be able to connect directly by using the bottom search bar on the server list and searching for: `[your_ip_address]:2456`.
+
+:::info
+If you cannot connect and receive `PlayFab` errors in console, you may need to disable crossplay support to resolve this as this is a current issue with the Linux version. To do so, run `nano /home/steam/Valheim-Server/start_server.sh` and remove the `-crossplay` flag.
+
+If you do require crossplay, an alternate solution is to instead install the Windows version and use Wine as a compatibility layer. See the **Installing Wine** section [on this example guide](vserver-linux-enshrouded.md) on how to do this. Then install the Valheim Windows server version via SteamCMD using:
+```
+steamcmd +@sSteamCmdForcePlatformType windows +force_install_dir '/home/steam/Valheim-Server' +login anonymous +app_update 896660 validate +quit
+```
+
+Once installed, use the following command to launch the Windows version through Wine instead: `xvfb-run wine /home/steam/Valheim-Server/StartServer.bat`
+:::
+
+## Conclusion
+
+Congratulations, you have successfully installed and configurated the Valheim server on your VPS! If you have any further questions or problems, please contact our support team, who are available to help you every day! 

--- a/docs/vserver-linux-vrising.md
+++ b/docs/vserver-linux-vrising.md
@@ -1,0 +1,102 @@
+---
+id: vserver-linux-vrising
+title: "VPS: V-Rising Dedicated Server Setup"
+description: Information about setting up an V-Rising Dedicated Server on a Linux VPS from ZAP-Hosting - ZAP-Hosting.com documentation
+sidebar_label: V-Rising
+services:
+  - vserver
+---
+
+import InlineVoucher from '@site/src/components/InlineVoucher';
+
+## Introduction
+Do you have a Linux VPS or root server and you want to install the V-Rising Dedicated server service on it? You are in the right place. In this guide, we will explain the step by step process of installing this service on your Linux server through the use of SteamCMD. We will be using Ubuntu in the examples, but the process should be very similar for other distributions.
+
+<InlineVoucher />
+
+## Preparation
+
+To begin with, connect to your VPS or root server via SSH. Use our [SSH Initial Access](vserver-linux-ssh.md) guide if you need help doing this.
+
+You will also have to complete a first-time setup for SteamCMD if this is your first time using this on your Linux server. Please use our [SteamCMD Linux Setup](vserver-linux-steamcmd.md) guide and ensure SteamCMD is fully setup before proceeding.
+
+### Installing Wine
+
+Currently, V-Rising does not have a native Linux-based server build, which means that there is an extra preparation step necessary to run the Windows server build on Linux. To resolve this, you will have to install the latest version of Wine which is a compatibility layer to allow Windows-native apps to run on Linux.
+
+Firstly, ensure that the `/etc/apt/keyrings/` directory exists, as this is necessary for Wine.
+```
+sudo mkdir -pm755 /etc/apt/keyrings
+```
+
+The next step is to download and store the Wine GPG key into this directory which verifies that the package is authentic.
+```
+sudo wget -O /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key
+```
+
+You will also have to save the sources list for WineHQ which can be done with the following pre-written source file:
+```
+sudo wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/dists/$(lsb_release -cs)/winehq-$(lsb_release -cs).sources
+```
+
+Run the update command again to ensure that your package changes are read and installed.
+```
+sudo apt update
+```
+
+Now you can download the latest version of Wine.
+```
+sudo apt install --install-recommends winehq-staging
+```
+
+Finally, you need to install a few extra packages to ensure Wine works well with the V-Rising server by running the following command.
+```
+sudo apt install cabextract winbind screen xvfb
+```
+
+You have successfully installed the Wine comaptibility layer, which will allow you to run V-Rising's Windows server build on your Linux server. Proceed with the installation.
+
+## Installation
+
+Begin by logging in to your `steam` user and heading over to the root `home/steam` user directory to keep things organised.
+```
+sudo -u steam -s
+cd ~
+```
+
+When logged in, you can start the installation process using the following command to easily start the installation through the use of SteamCMD directly to your `steam` user. By using the `+@sSteamCmdForcePlatformType windows` parameter, you forcefully ensure that the Windows binaries are installed.
+```
+steamcmd +@sSteamCmdForcePlatformType windows +force_install_dir '/home/steam/V-Rising-Server' +login anonymous +app_update 1829350 validate +quit
+```
+
+Please be patient as the download completes, it can take some time for games with larger sizes. Once successful, you will see a success message appear confirming this.
+
+## Configuration
+
+By this stage, you have finished the setup for your V-Rising server. You can perform further server configuration by directing editing the launch file.
+
+You will be able to adjust all configuration parameters by accessing and editing the **ServerGameSettings.json** and **ServerHostSettings.json** configuration files found within the Settings folder.
+```
+nano /home/steam/V-Rising-Server/VRisingServer_Data/StreamingAssets/Settings/ServerGameSettings.json
+nano /home/steam/V-Rising-Server/VRisingServer_Data/StreamingAssets/Settings/ServerHostSettings.json
+```
+
+See our [V-Rising Server Configuration guide](vrising-configuration.md) to view all of the available server options and what they each do.
+
+## Starting & Connecting to your server
+
+Now it is time to start your server. Head over to the main game directory, where we recommend creating a copy of the example batch file.
+```
+cp /home/steam/V-Rising-Server/start_server_example.bat /home/steam/V-Rising-Server/start_server.bat
+```
+
+You can choose to edit the file. Once ready, run the new **start_server.bat** executable file using the command below. Ensure that you add the **xvfb-run** and **wine** commands to run it through the Wine compatibility layer.
+```
+xvfb-run wine /home/steam/V-Rising-Server/start_server.bat
+```
+
+You should now see logs appear in your command prompt which signals that the start up was successful. Please note that first time start up could take some time as everything is setup. Alternatively, you will be able to connect directly by using the bottom search bar on the server list and searching for: `[your_ip_address]:8211`.
+
+## Conclusion
+
+Congratulations, you have successfully installed and configurated the V-Rising server on your VPS! If you have any further questions or problems, please contact our support team, who are available to help you every day! 

--- a/docs/vserver-linux-vrising.md
+++ b/docs/vserver-linux-vrising.md
@@ -73,4 +73,6 @@ You should now see logs appear in your command prompt which signals that the sta
 
 ## Conclusion
 
-Congratulations, you have successfully installed and configurated the V-Rising server on your VPS! If you have any further questions or problems, please contact our support team, who are available to help you every day! 
+Congratulations, you have successfully installed and configurated the V-Rising server on your VPS! As a next step, we recommend looking over our [Setup Linux Service](vserver-linux-create-gameservice.md) guide, which covers setting up your new dedicated game server as a service. This provides various benefits including automatic server launching on boot, automatic server updates, easy management and access to logs, plus much more!
+
+If you have any further questions or problems, please contact our support team, who are available to help you every day!

--- a/docs/vserver-linux-vrising.md
+++ b/docs/vserver-linux-vrising.md
@@ -20,41 +20,11 @@ To begin with, connect to your VPS or root server via SSH. Use our [SSH Initial 
 
 You will also have to complete a first-time setup for SteamCMD if this is your first time using this on your Linux server. Please use our [SteamCMD Linux Setup](vserver-linux-steamcmd.md) guide and ensure SteamCMD is fully setup before proceeding.
 
-### Installing Wine
+:::info Wine Compatibility Layer
+V-Rising currently does not offer a native Linux-based server build, which means that there is an extra preparation step necessary to run the Windows server build on Linux.
 
-Currently, V-Rising does not have a native Linux-based server build, which means that there is an extra preparation step necessary to run the Windows server build on Linux. To resolve this, you will have to install the latest version of Wine which is a compatibility layer to allow Windows-native apps to run on Linux.
-
-Firstly, ensure that the `/etc/apt/keyrings/` directory exists, as this is necessary for Wine.
-```
-sudo mkdir -pm755 /etc/apt/keyrings
-```
-
-The next step is to download and store the Wine GPG key into this directory which verifies that the package is authentic.
-```
-sudo wget -O /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key
-```
-
-You will also have to save the sources list for WineHQ which can be done with the following pre-written source file:
-```
-sudo wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/dists/$(lsb_release -cs)/winehq-$(lsb_release -cs).sources
-```
-
-Run the update command again to ensure that your package changes are read and installed.
-```
-sudo apt update
-```
-
-Now you can download the latest version of Wine.
-```
-sudo apt install --install-recommends winehq-staging
-```
-
-Finally, you need to install a few extra packages to ensure Wine works well with the V-Rising server by running the following command.
-```
-sudo apt install cabextract winbind screen xvfb
-```
-
-You have successfully installed the Wine comaptibility layer, which will allow you to run V-Rising's Windows server build on your Linux server. Proceed with the installation.
+You have to complete a one-time installation of the **Wine** compatibility layer if this is your first time using this on your Linux server. Please use our quick [Wine Compatibility Layer Setup](vserver-linux-wine.md) guide to set this up before proceeding.
+:::
 
 ## Installation
 

--- a/docs/vserver-linux-wine.md
+++ b/docs/vserver-linux-wine.md
@@ -1,0 +1,58 @@
+---
+id: vserver-linux-wine
+title: "VPS: Wine Compatibility Layer Setup"
+description: Information about setting up the Wine (WineHQ) Windows compatibility layer on a Linux VPS from ZAP-Hosting - ZAP-Hosting.com documentation
+sidebar_label: Setup Wine Compatibility Layer
+services:
+  - vserver
+---
+
+import InlineVoucher from '@site/src/components/InlineVoucher';
+
+## Introduction
+
+Wine is an open-source compatibility layer for Linux which allows software that is originally developed for Windows to run on Linux systems. This is especially important for dedicated game servers that only offer Windows server files and may be required as a prerequisite for our other Linux dedicated game server guides. In this guide, we will explore the first-time setup process for installing Wine to your Linux server. We will be using Ubuntu in the examples, but the process should be very similar for other distributions.
+
+<InlineVoucher />
+
+## Preparation
+
+To begin with, connect to your VPS or root server via SSH. Use our [SSH Initial Access](vserver-linux-ssh.md) guide if you need help doing this.
+
+## Installing Wine
+
+Begin the installation process by ensuring that the `/etc/apt/keyrings/` directory exists, as this is necessary for Wine.
+```
+sudo mkdir -pm755 /etc/apt/keyrings
+```
+
+Next, download and store the Wine GPG key into this directory which verifies that the package is authentic.
+```
+sudo wget -O /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key
+```
+
+You will also have to save the sources list for WineHQ which can be done with the following pre-written command:
+```
+sudo wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/dists/$(lsb_release -cs)/winehq-$(lsb_release -cs).sources
+```
+
+Run the update command to ensure that your package changes are read and installed.
+```
+sudo apt update
+```
+
+Now you can proceed with the main step of downloading the latest version of Wine. This could take some time to complete.
+```
+sudo apt install --install-recommends winehq-staging
+```
+
+Finally, you need to install a few extra packages to ensure that Wine will work well with dedicated game server by running the following command.
+```
+sudo apt install cabextract winbind screen xvfb
+```
+
+### Conclusion
+
+You have now successfully setup the Wine comaptibility layer, which will allow you to run Windows programs on your Linux server. With this important prerequisite installed, you can now proceed to install dedicated game servers even if they are built for Windows.
+
+We recommend checking out the other guides in this section which cover installing specific games through the use of SteamCMD and potentially Wine for Windows-based dedicated server files.

--- a/docs/vserver-linux-wine.md
+++ b/docs/vserver-linux-wine.md
@@ -51,7 +51,7 @@ Finally, you need to install a few extra packages to ensure that Wine will work 
 sudo apt install cabextract winbind screen xvfb
 ```
 
-### Conclusion
+## Conclusion
 
 You have now successfully setup the Wine comaptibility layer, which will allow you to run Windows programs on your Linux server. With this important prerequisite installed, you can now proceed to install dedicated game servers even if they are built for Windows.
 

--- a/docs/vserver-windows-ark.md
+++ b/docs/vserver-windows-ark.md
@@ -1,6 +1,6 @@
 ---
 id: vserver-windows-ark
-title: "VPS: ARK Survival Evolved Dedicated Server Setup"
+title: "VPS: ARK Survival Evolved Dedicated Server Windows Setup"
 description: Information about setting up an ARK Survival Evolved Dedicated Server on a VPS/Root server - ZAP-Hosting.com documentation
 sidebar_label: ARK Survival Evolved Dedicated Server Setup
 services:

--- a/docs/vserver-windows-arksurvivalascended.md
+++ b/docs/vserver-windows-arksurvivalascended.md
@@ -1,7 +1,7 @@
 ---
 id: vserver-windows-arksurvivalascended
 title: "VPS: ARK Survival Ascended Dedicated Server Setup"
-description: Information about setting up an ARK Survival Ascended Dedicated Server on a VPS/Root server/Dedicated Server - ZAP-Hosting.com documentation
+description: Information about setting up an ARK Survival Ascended Dedicated Server on a Windows VPS from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: ARK Survival Ascended
 services:
   - vserver

--- a/docs/vserver-windows-arksurvivalascended.md
+++ b/docs/vserver-windows-arksurvivalascended.md
@@ -1,6 +1,6 @@
 ---
 id: vserver-windows-arksurvivalascended
-title: "VPS: ARK Survival Ascended Dedicated Server Setup"
+title: "VPS: ARK Survival Ascended Dedicated Server Windows Setup"
 description: Information about setting up an ARK Survival Ascended Dedicated Server on a Windows VPS from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: ARK Survival Ascended
 services:

--- a/docs/vserver-windows-enshrouded.md
+++ b/docs/vserver-windows-enshrouded.md
@@ -1,6 +1,6 @@
 ---
 id: vserver-windows-enshrouded
-title: "VPS: Enshrouded Dedicated Server Setup"
+title: "VPS: Enshrouded Dedicated Server Windows Setup"
 description: Information about setting up an Enshrouded Dedicated Server on a Windows VPS from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: Enshrouded
 services:

--- a/docs/vserver-windows-enshrouded.md
+++ b/docs/vserver-windows-enshrouded.md
@@ -1,7 +1,7 @@
 ---
 id: vserver-windows-enshrouded
 title: "VPS: Enshrouded Dedicated Server Setup"
-description: Information about setting up an Enshrouded Dedicated Server on a VPS/Root server - ZAP-Hosting.com documentation
+description: Information about setting up an Enshrouded Dedicated Server on a Windows VPS from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: Enshrouded
 services:
   - vserver

--- a/docs/vserver-windows-foundry.md
+++ b/docs/vserver-windows-foundry.md
@@ -1,7 +1,7 @@
 ---
 id: vserver-windows-foundry
 title: "VPS: Foundry Dedicated Server Setup"
-description: Information about setting up a Foundry Dedicated Server on a VPS/Root server - ZAP-Hosting.com documentation
+description: Information about setting up a Foundry Dedicated Server on a Windows VPS from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: Foundry
 services:
   - vserver

--- a/docs/vserver-windows-foundry.md
+++ b/docs/vserver-windows-foundry.md
@@ -1,6 +1,6 @@
 ---
 id: vserver-windows-foundry
-title: "VPS: Foundry Dedicated Server Setup"
+title: "VPS: Foundry Dedicated Server Windows Setup"
 description: Information about setting up a Foundry Dedicated Server on a Windows VPS from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: Foundry
 services:

--- a/docs/vserver-windows-fs-19.md
+++ b/docs/vserver-windows-fs-19.md
@@ -1,6 +1,6 @@
 ---
 id: vserver-windows-fs-19
-title: "VPS: Farming Simulator 2019 Dedicated Server Setup"
+title: "VPS: Farming Simulator 2019 Dedicated Server Windows Setup"
 description: Information about setting up a Farming Simulator 2019 Dedicated Server on a Windows VPS from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: Farming Simulator 2019
 services:

--- a/docs/vserver-windows-fs-19.md
+++ b/docs/vserver-windows-fs-19.md
@@ -1,7 +1,7 @@
 ---
 id: vserver-windows-fs-19
 title: "VPS: Farming Simulator 2019 Dedicated Server Setup"
-description: Information on how to install and set up a Farming Simulator Dedicated Server 2019 on your Windows VPS from ZAP-Hosting - ZAP-Hosting.com documentation
+description: Information about setting up a Farming Simulator 2019 Dedicated Server on a Windows VPS from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: Farming Simulator 2019
 services:
   - vserver

--- a/docs/vserver-windows-fs-22-epic.md
+++ b/docs/vserver-windows-fs-22-epic.md
@@ -1,6 +1,6 @@
 ---
 id: vserver-windows-fs-22-epic
-title: "VPS: Farming Simulator 2022 (Epic Games) Dedicated Server Setup"
+title: "VPS: Farming Simulator 2022 (Epic Games) Dedicated Server Windows Setup"
 description: Information about setting up a Farming Simulator 2022 Dedicated Server (Epic Games version) on a Windows VPS from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: Farming Simulator 2022 (Epic Games)
 services:

--- a/docs/vserver-windows-fs-22-epic.md
+++ b/docs/vserver-windows-fs-22-epic.md
@@ -1,7 +1,7 @@
 ---
 id: vserver-windows-fs-22-epic
 title: "VPS: Farming Simulator 2022 (Epic Games) Dedicated Server Setup"
-description: Information on how to install and set up a Farming Simulator 2022 dedicated server for the Epic Games version on your Windows VPS from ZAP-Hosting - ZAP-Hosting.com documentation
+description: Information about setting up a Farming Simulator 2022 Dedicated Server (Epic Games version) on a Windows VPS from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: Farming Simulator 2022 (Epic Games)
 services:
   - vserver

--- a/docs/vserver-windows-fs-22.md
+++ b/docs/vserver-windows-fs-22.md
@@ -1,6 +1,6 @@
 ---
 id: vserver-windows-fs-22
-title: "VPS: Farming Simulator 2022 Dedicated Server Setup"
+title: "VPS: Farming Simulator 2022 Dedicated Server Windows Setup"
 description: Information about setting up a Farming Simulator 2022 Dedicated Server on a Windows VPS from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: Farming Simulator 2022
 services:

--- a/docs/vserver-windows-fs-22.md
+++ b/docs/vserver-windows-fs-22.md
@@ -1,7 +1,7 @@
 ---
 id: vserver-windows-fs-22
 title: "VPS: Farming Simulator 2022 Dedicated Server Setup"
-description: Information on how to install and set up a Farming Simulator Dedicated Server 2022 on your Windows VPS from ZAP-Hosting - ZAP-Hosting.com documentation
+description: Information about setting up a Farming Simulator 2022 Dedicated Server on a Windows VPS from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: Farming Simulator 2022
 services:
   - vserver

--- a/docs/vserver-windows-mythofempires.md
+++ b/docs/vserver-windows-mythofempires.md
@@ -1,7 +1,7 @@
 ---
 id: vserver-windows-mythofempires
 title: "VPS: Myth of Empires Dedicated Server Setup"
-description: Information about setting up a Myth of Empires Dedicated Server on a VPS/Rootserver - ZAP-Hosting.com documentation
+description: Information about setting up a Myth of Empires Dedicated Server on a Windows VPS from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: MOE Dedicated Server Setup
 services:
   - vserver

--- a/docs/vserver-windows-mythofempires.md
+++ b/docs/vserver-windows-mythofempires.md
@@ -1,6 +1,6 @@
 ---
 id: vserver-windows-mythofempires
-title: "VPS: Myth of Empires Dedicated Server Setup"
+title: "VPS: Myth of Empires Dedicated Server Windows Setup"
 description: Information about setting up a Myth of Empires Dedicated Server on a Windows VPS from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: MOE Dedicated Server Setup
 services:

--- a/docs/vserver-windows-palworld.md
+++ b/docs/vserver-windows-palworld.md
@@ -1,6 +1,6 @@
 ---
 id: vserver-windows-palworld
-title: "VPS: Palworld Dedicated Server Setup"
+title: "VPS: Palworld Dedicated Server Windows Setup"
 description: Information about setting up a Palworld Dedicated Server on a Windows VPS from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: Palworld
 services:

--- a/docs/vserver-windows-palworld.md
+++ b/docs/vserver-windows-palworld.md
@@ -1,7 +1,7 @@
 ---
 id: vserver-windows-palworld
 title: "VPS: Palworld Dedicated Server Setup"
-description: Information about setting up a Palworld Dedicated Server on a VPS/Root server - ZAP-Hosting.com documentation
+description: Information about setting up a Palworld Dedicated Server on a Windows VPS from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: Palworld
 services:
   - vserver

--- a/docs/vserver-windows-satisfactory.md
+++ b/docs/vserver-windows-satisfactory.md
@@ -1,7 +1,7 @@
 ---
 id: vserver-windows-satisfactory
 title: "VPS: Satisfactory Dedicated Server Setup"
-description: Information about setting up a Satisfactory Dedicated Server on a VPS/Root server - ZAP-Hosting.com documentation
+description: Information about setting up a Satisfactory Dedicated Server on a Windows VPS from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: Satisfactory
 services:
   - vserver

--- a/docs/vserver-windows-satisfactory.md
+++ b/docs/vserver-windows-satisfactory.md
@@ -1,6 +1,6 @@
 ---
 id: vserver-windows-satisfactory
-title: "VPS: Satisfactory Dedicated Server Setup"
+title: "VPS: Satisfactory Dedicated Server Windows Setup"
 description: Information about setting up a Satisfactory Dedicated Server on a Windows VPS from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: Satisfactory
 services:

--- a/docs/vserver-windows-soulmask.md
+++ b/docs/vserver-windows-soulmask.md
@@ -1,6 +1,6 @@
 ---
 id: vserver-windows-soulmask
-title: "VPS: Soulmask Dedicated Server Setup"
+title: "VPS: Soulmask Dedicated Server Windows Setup"
 description: Information about setting up a Soulmask Dedicated Server on a Windows VPS from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: Soulmask
 services:

--- a/docs/vserver-windows-soulmask.md
+++ b/docs/vserver-windows-soulmask.md
@@ -1,7 +1,7 @@
 ---
 id: vserver-windows-soulmask
 title: "VPS: Soulmask Dedicated Server Setup"
-description: Information about setting up a Soulmask Dedicated Server on a vServer/Rootserver - ZAP-Hosting.com documentation
+description: Information about setting up a Soulmask Dedicated Server on a Windows VPS from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: Soulmask
 services:
   - vserver

--- a/docs/vserver-windows-valheim.md
+++ b/docs/vserver-windows-valheim.md
@@ -1,7 +1,7 @@
 ---
 id: vserver-windows-valheim
 title: "VPS: Valheim Dedicated Server Setup"
-description: Information about setting up a Valheim Dedicated Server on a VPS/Root server - ZAP-Hosting.com documentation
+description: Information about setting up a Valheim Dedicated Server on a Windows VPS from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: Valheim
 services:
   - vserver

--- a/docs/vserver-windows-valheim.md
+++ b/docs/vserver-windows-valheim.md
@@ -1,6 +1,6 @@
 ---
 id: vserver-windows-valheim
-title: "VPS: Valheim Dedicated Server Setup"
+title: "VPS: Valheim Dedicated Server Windows Setup"
 description: Information about setting up a Valheim Dedicated Server on a Windows VPS from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: Valheim
 services:

--- a/docs/vserver-windows-vrising.md
+++ b/docs/vserver-windows-vrising.md
@@ -1,7 +1,7 @@
 ---
 id: vserver-windows-vrising
 title: "VPS: V-Rising Dedicated Server Setup"
-description: Information on how to install and set up a V-Rising Server on your Windows VPS from ZAP-Hosting - ZAP-Hosting.com documentation
+description: Information about setting up a V-Rising Dedicated Server on a Windows VPS from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: V-Rising
 services:
   - vserver

--- a/docs/vserver-windows-vrising.md
+++ b/docs/vserver-windows-vrising.md
@@ -1,6 +1,6 @@
 ---
 id: vserver-windows-vrising
-title: "VPS: V-Rising Dedicated Server Setup"
+title: "VPS: V-Rising Dedicated Server Windows Setup"
 description: Information about setting up a V-Rising Dedicated Server on a Windows VPS from ZAP-Hosting - ZAP-Hosting.com documentation
 sidebar_label: V-Rising
 services:

--- a/sidebars.js
+++ b/sidebars.js
@@ -1430,6 +1430,7 @@ const sidebars = {
       label: "Gameserver services",
       items: [
         'vserver-linux-steamcmd',
+        'vserver-linux-wine',
         'vserver-linux-arksurvivalascended',
         'vserver-linux-enshrouded',
         'vserver-linux-foundry',
@@ -1581,6 +1582,7 @@ const sidebars = {
       label: "Gameserver services",
       items: [
         'dedicated-linux-steamcmd',
+        'dedicated-linux-wine',
         'dedicated-linux-arksurvivalascended',
         'dedicated-linux-enshrouded',
         'dedicated-linux-foundry',

--- a/sidebars.js
+++ b/sidebars.js
@@ -1427,16 +1427,13 @@ const sidebars = {
     },
     {
       type: "category",
-      label: "Gameserver services",
+      label: "Dedicated Game Servers",
       items: [
         'vserver-linux-steamcmd',
         'vserver-linux-wine',
         'vserver-linux-arksurvivalascended',
         'vserver-linux-enshrouded',
         'vserver-linux-foundry',
-        'vserver-linux-fs-19',
-        'vserver-linux-fs-22',
-        'vserver-linux-fs-22-epic',
         'vserver-linux-mythofempires',
         'vserver-linux-palworld',
         'vserver-linux-satisfactory',
@@ -1481,7 +1478,7 @@ const sidebars = {
     },
     {
       type: "category",
-      label: "Gameserver services",
+      label: "Dedicated Game Servers",
       items: [
         'vserver-windows-arksurvivalascended',
         'vserver-windows-enshrouded',
@@ -1579,16 +1576,13 @@ const sidebars = {
     },
     {
       type: "category",
-      label: "Gameserver services",
+      label: "Dedicated Game Servers",
       items: [
         'dedicated-linux-steamcmd',
         'dedicated-linux-wine',
         'dedicated-linux-arksurvivalascended',
         'dedicated-linux-enshrouded',
         'dedicated-linux-foundry',
-        'dedicated-linux-fs-19',
-        'dedicated-linux-fs-22',
-        'dedicated-linux-fs-22-epic',
         'dedicated-linux-mythofempires',
         'dedicated-linux-palworld',
         'dedicated-linux-satisfactory',
@@ -1629,7 +1623,7 @@ const sidebars = {
     },
     {
       type: "category",
-      label: "Gameserver services",
+      label: "Dedicated Game Servers",
       items: [
         'dedicated-windows-arksurvivalascended',
         'dedicated-windows-enshrouded',

--- a/sidebars.js
+++ b/sidebars.js
@@ -1431,6 +1431,7 @@ const sidebars = {
       items: [
         'vserver-linux-steamcmd',
         'vserver-linux-wine',
+        'vserver-linux-create-gameservice',
         'vserver-linux-arksurvivalascended',
         'vserver-linux-enshrouded',
         'vserver-linux-foundry',
@@ -1580,6 +1581,7 @@ const sidebars = {
       items: [
         'dedicated-linux-steamcmd',
         'dedicated-linux-wine',
+        'dedicated-linux-create-gameservice',
         'dedicated-linux-arksurvivalascended',
         'dedicated-linux-enshrouded',
         'dedicated-linux-foundry',

--- a/sidebars.js
+++ b/sidebars.js
@@ -1426,6 +1426,25 @@ const sidebars = {
       ],
     },
     {
+      type: "category",
+      label: "Gameserver services",
+      items: [
+        'vserver-linux-steamcmd',
+        'vserver-linux-arksurvivalascended',
+        'vserver-linux-enshrouded',
+        'vserver-linux-foundry',
+        'vserver-linux-fs-19',
+        'vserver-linux-fs-22',
+        'vserver-linux-fs-22-epic',
+        'vserver-linux-mythofempires',
+        'vserver-linux-palworld',
+        'vserver-linux-satisfactory',
+        'vserver-linux-soulmask',
+        'vserver-linux-valheim',
+        'vserver-linux-vrising',
+      ]
+    },
+    {
       type: 'html',
       className: 'sidebar-title',
       value: (() => {
@@ -1556,6 +1575,25 @@ const sidebars = {
         'dedicated-linux-webserver',
         'dedicated-linux-xrdp',
       ],
+    },
+    {
+      type: "category",
+      label: "Gameserver services",
+      items: [
+        'dedicated-linux-steamcmd',
+        'dedicated-linux-arksurvivalascended',
+        'dedicated-linux-enshrouded',
+        'dedicated-linux-foundry',
+        'dedicated-linux-fs-19',
+        'dedicated-linux-fs-22',
+        'dedicated-linux-fs-22-epic',
+        'dedicated-linux-mythofempires',
+        'dedicated-linux-palworld',
+        'dedicated-linux-satisfactory',
+        'dedicated-linux-soulmask',
+        'dedicated-linux-valheim',
+        'dedicated-linux-vrising',
+      ]
     },
     {
       type: "category",


### PR DESCRIPTION
New **Dedicated Game Servers** section for Linux, similar to Windows but completely new since it requires completely different setup. This includes:
- Setup SteamCMD general guide
- Setup Wine Compatibility Layer general guide
- Setup Linux Service general guide
- Ark: SA
- Enshrouded
- Foundry
- Myth of Empires
- Palworld
- Satisfactory
- Soulmask
- Valheim
- V-Rising

Within the game guides, references are made to the general guides to reduce the need for repetition, and to have separate guides that can be SEO'd well. I've also cloned them as usual, so that there is a VPS/root and Dedicated Server version.

Also adjusted some of the Windows guides, specifically metadata to ensure it clarify the platform the guide is made for, alongside the name from "Gameserver Services" to "Dedicated Game Services" since this makes more sense.