### PR TITLE
fix: mobile search bar not visible when selected on mobile

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -247,8 +247,16 @@ p {
   }
 }
 
-@media (max-width: 996px){
+@media (max-width: 500px){
   .navbar__search-input {
       width: 2rem;
+  }
+  .navbar__search-input:focus {
+    width: 15rem;
+    transition: width 0.2s ease-out;
+  }
+
+  .navbar__search-input:not(:focus) {
+    transition: width 0.2s ease-out;
   }
 }


### PR DESCRIPTION
this fixes #1331 and introduces a nice little animation when selecting the search bar on mobile:

https://github.com/user-attachments/assets/f35453c9-1a88-4884-b18f-6dc1c05b132a

