### PR TITLE
fix: only consider images inside articles for zoom

### DIFF
--- a/src/theme/Root.js
+++ b/src/theme/Root.js
@@ -8,7 +8,7 @@ export default function Root({ children }) {
 
   useEffect(() => {
     const applyMediumZoom = () => {
-      mediumZoom('img');
+      mediumZoom("article img");
     };
 
     const intervalId = setInterval(() => {


### PR DESCRIPTION
Fixes an issue where images outside the docs article are zoomable (for example, the header logo).

thanks @3incognito for the report