### PR TITLE
fix: video link typo & tweak title

### DIFF
--- a/docs/welcome.md
+++ b/docs/welcome.md
@@ -16,7 +16,7 @@ Our goal is to make knowledge accessible and understandable. That's why we've de
 
 We cover a wide range of topics and regularly update our content to ensure you're always up to date and can apply the best practices. From basic setup guides to advanced configuration techniques.
 
-<YouTube videoId="2wJ6ZJ6ZVk" imageSrc="https://screensaver01.zap-hosting.com/index.php/s/LHjDHL43wHSj5aE/preview" title="ZAP-Hosting Documentation" description="Feel like you understand better when you see things in action? We’ve got you! Dive into our video that breaks it all down for you. Whether you're in a rush or just prefer to soak up information in the most engaging way possible!"/>
+<YouTube videoId="-2wJ6ZJ6ZVk" imageSrc="https://screensaver01.zap-hosting.com/index.php/s/LHjDHL43wHSj5aE/preview" title="Welcome to ZAP-Docs!" description="Feel like you understand better when you see things in action? We’ve got you! Dive into our video that breaks it all down for you. Whether you're in a rush or just prefer to soak up information in the most engaging way possible!"/>
 
 ## Gameserver
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/welcome.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/welcome.md
@@ -16,7 +16,7 @@ Unser Ziel ist es, Wissen zugänglich und verständlich zu machen. Deshalb haben
 
 Wir decken eine breite Palette an Themen ab und aktualisieren unsere Inhalte regelmäßig, um sicherzustellen, dass du immer auf dem neuesten Stand bist und die besten Praktiken anwenden kannst. Von grundlegenden Einrichtungsanleitungen bis hin zu fortgeschrittenen Konfigurationstechniken. 
 
-<YouTube videoId="2wJ6ZJ6ZVk" imageSrc="https://screensaver01.zap-hosting.com/index.php/s/LHjDHL43wHSj5aE/preview" title="ZAP-Hosting Dokumentation" description="Hast du das Gefühl, dass du etwas besser verstehst, wenn du es in Aktion siehst? Wir haben etwas für dich! Tauche ab in unser Video, welches alles für dich zusammenfasst. Egal, ob du es eilig hast oder einfach nur Informationen auf möglichst verständliche Art und Weise aufnehmen möchtest!"/>
+<YouTube videoId="-2wJ6ZJ6ZVk" imageSrc="https://screensaver01.zap-hosting.com/index.php/s/LHjDHL43wHSj5aE/preview" title="Willkommen bei ZAP-Docs!" description="Hast du das Gefühl, dass du etwas besser verstehst, wenn du es in Aktion siehst? Wir haben etwas für dich! Tauche ab in unser Video, welches alles für dich zusammenfasst. Egal, ob du es eilig hast oder einfach nur Informationen auf möglichst verständliche Art und Weise aufnehmen möchtest!"/>
 
 ## Gameserver
 Perfektioniere und Nutze den vollen Umfang deines Gameservers. Mit unserer Expertise bringen wir dein Gaming auf ein neues Level. Unsere detaillierten Anleitungen für über 100 verschiedene Spiele und die dazugehörigen Erweiterungen/Modifikationen ermöglichen es dir, ein tiefgreifendes Verständnis für die Konfiguration und Verwaltung deiner Gameserver zu entwickeln.


### PR DESCRIPTION
Fixed a missing `-` at the beginning of the URL slug & changed title slightly.