### PR TITLE
tweak: adjust affiliate guide contents

### DIFF
--- a/docs/account-affiliate.md
+++ b/docs/account-affiliate.md
@@ -8,11 +8,13 @@ sidebar_label: Affiliate Program
 ![Affiliate Program](https://screensaver01.zap-hosting.com/index.php/s/GoXwRnHrRARc4jk/preview)
 
 ## Introduction
+
 Our Affiliate program allows you to earn free money by referring new customers to ZAP-Hosting. You can access this by heading over to the [Affiliate Page](https://zap-hosting.com/en/customer/affiliate/) on our website.
 
 Through the Affiliate page, you will be able to manage affiliate links, banners and access your dedicated affiliate coupon code which will provide any new customers with an awesome permanent **20% off** their server price for its entire runtime.
 
 ## How the Affiliate Program works
+
 You will be able to publish and promote all the affiliate generated content where ever you believe you could gain some traction, for example on your website, a forum or on your social media account. It is entirely up to you.
 
 When someone clicks on the link, and buys a product on our [website](https://zap-hosting.com/), you will be eligible to a sales commission. 
@@ -22,19 +24,13 @@ The user could also pair their purcahse with your affiliate voucher code during 
 :::
 
 ## Commissions
-Through the Affiliate program, the exact amount of commission depends on the type of product that the person using your link has purchased. It can be as great as **50%** for many products.
 
-You can view the latest and up-to-date commission % values through the [Conditions Section](https://zap-hosting.com/en/customer/affiliate/conditions/) on the Affiliate Page.
+Through the Affiliate program, the exact amount of commission depends on the type of product that the person using your link has purchased. It can be as high as **50%** for some products.
 
-:::info
-The affiliate credit display is based on payments including VAT. If you are not a German business/individual who has to add VAT to their invoices, you have to deduct VAT before sending your invoice. This means that you have to deduct the VAT from your displayed affiliate balance when paying out. You can do this by dividing the displayed amount by 1.19 (19% German VAT).
-
-Example: You have €100 affiliate credit. You should invoice: 100 / 1.19 = €84.03 in total if you choose PayPal as your payout option. Otherwise, if you pay out to your cashbox (ZAP Coins), you will receive the full amount.
-
-If VAT has to be shown in the invoice, the full amount will be shown in the invoice including VAT. With an affiliate credit of 100€, an invoice of 100€, consisting of €84.03 invoice amount and €15.97 VAT will be sent. Non-German invoices generally will not have to add VAT to the invoice.
-:::
+You can view the latest and up-to-date commission percentage (%) values through the [Conditions Section](https://zap-hosting.com/en/customer/affiliate/conditions/) on the Affiliate Page.
 
 ## Creating an Affiliate link & banner
+
 To create a new affiliate link or banner, simply head over to the main [Affiliate Page](https://zap-hosting.com/en/customer/affiliate/) and scroll down. You will be able to view your existing links and banners, but you will also be able to create new ones through the green **Create advertising material** buton.
 
 ![](https://screensaver01.zap-hosting.com/index.php/s/zHjcrXACxAoA7qJ/preview)
@@ -44,6 +40,7 @@ This will open up a menu in where you will be able to customise a range of value
 Each of the values will be explained in detail below:
 
 #### Alias
+
 In this field, you can specify the unique alias URL ending that should be used for your banner or link. This cannot be duplicate, so it must be available.
 
 For example, specifying `ilovezap` in this field will mean that your banner/link will be accessible through `https://zap-hosting.com/ilovezap`.
@@ -51,6 +48,7 @@ For example, specifying `ilovezap` in this field will mean that your banner/link
 If you do not specify your own alias, a random one will be automatically generated for you.
 
 #### Choose a template or linktext
+
 This field is dependant on the type of advertising material you have picked. 
 
 If you picked **banner**, you will have to choose a template. You can do so by using the drop down menu and selecting one of our many default banners that fits your needs and looks.
@@ -60,6 +58,7 @@ On the other hand, if you picked **link**, you can specify a linktext which will
 You can see this here: `<a href="https://zap-hosting.com/diesisteinaffiliatelink">click me</a>`
 
 #### Selecting the target product
+
 In these fields you can pick a range of options to customise to your own likings where your new affiliate link will redirect to.
 
 We recommend toggling the **Shop products** on because it will lead the customer directly to the server configurator for the selected product, rather than the product page. The fewer pages a user has to go through, increases the likelihood that an order will be placed.
@@ -67,6 +66,7 @@ We recommend toggling the **Shop products** on because it will lead the customer
 Next you can select the **Product** field using the drop down menu. This is where your new affiliate link will redirect the user to when they access it. If you select a gameserver, you will have an addition **Game** option which you will have to select, otherwise the product is the only option.
 
 #### Finshing the creation process
+
 Once you have filled everything in to your liking, simply press the green **Create** button to proceed in creating your banner or link. You should receive an success message if everything is correct, and your new banner or link will appear under the **Your Banners/Links** section once you scroll down.
 
 ![](https://screensaver01.zap-hosting.com/index.php/s/THYSkKPHtSpMgiy/preview)
@@ -89,9 +89,9 @@ On the menu prompt, select **ZAP Coin balance** as the option. Choose whether yo
 
 ![](https://screensaver01.zap-hosting.com/index.php/s/HyCXmc2KzqSY4yL/preview)
 
-### Real money (PayPal)
+### Money (PayPal)
 
-We currently only offer payouts into real money via PayPal. In order to payout via PayPal, you will have to create and send an invoice to us referencing your customer ZAP ID.
+We currently only offer payouts into money via PayPal. In order to payout via PayPal, you will have to create and send an invoice to us referencing your customer ZAP ID.
 
 Head over to the [PayPal Invoice Creator](https://www.paypal.com/invoice/create?fromWidget=newuser) and fill in the invoice as appropriate:
 

--- a/i18n/de/docusaurus-plugin-content-docs/current/account-affiliate.md
+++ b/i18n/de/docusaurus-plugin-content-docs/current/account-affiliate.md
@@ -8,11 +8,13 @@ sidebar_label: Affiliate Programm
 ![Affiliate Program](https://screensaver01.zap-hosting.com/index.php/s/GoXwRnHrRARc4jk/preview)
 
 ## Einführung
+
 Unser Partnerprogramm ermöglicht es dir, kostenlos Geld zu verdienen, indem du neue Kunden an ZAP-Hosting vermittelst. Du kannst darauf zugreifen, indem du auf die [Affiliate-Seite](https://zap-hosting.com/en/customer/affiliate/) auf unserer Website gehst.
 
 Auf der Affiliate-Seite kannst du Affiliate-Links und Banner verwalten und auf deinen eigenen Affiliate-Gutscheincode zugreifen, mit dem neue Kunden für die gesamte Laufzeit des Programms einen Rabatt von **20%** auf deren Serverpreis erhalten.
 
 ## So funktioniert das Partnerprogramm
+
 Du kannst alle von den Partnern erstellten Inhalte dort veröffentlichen und bewerben, wo du glaubst, dass sie gut ankommen, z. B. auf deiner Website, in einem Forum oder auf deinem Social-Media-Konto. Das ist ganz dir überlassen.
 
 Wenn jemand auf den Link klickt und ein Produkt auf unserer [Website](https://zap-hosting.com/) kauft, erhältst du eine Verkaufsprovision. 
@@ -22,19 +24,13 @@ Der/die Nutzer/in kann seinen/ihren Einkauf während des Bestellvorgangs auch mi
 :::
 
 ## Provisionen
+
 Im Rahmen des Partnerprogramms hängt die genaue Höhe der Provision von der Art des Produkts ab, welche die Person, die deinen Link benutzt hat, gekauft hat. Diese kann bei vielen Produkten bis zu **50%** betragen.
 
 Die neuesten und aktuellsten Werte für die Provisionen kannst du im [Abschnitt Bedingungen](https://zap-hosting.com/en/customer/affiliate/conditions/) auf der Partnerseite einsehen.
 
-:::info
-Die Anzeige des Partnerguthabens basiert auf Zahlungen inklusive Mehrwertsteuer. Wenn du kein deutsches Unternehmen/keine deutsche Privatperson bist, die die Mehrwertsteuer auf seine Rechnungen aufschlagen muss, musst du die Mehrwertsteuer vor der Einreichung deiner Rechnung abziehen. Das bedeutet, dass du bei der Auszahlung die Mehrwertsteuer von deinem angezeigten Partnerguthaben abziehen musst. Du kannst dies tun, indem du den angezeigten Betrag durch 1,19 (19% deutsche Mehrwertsteuer) teilst.
-
-Beispiel: Du hast 100 € Affiliate-Guthaben. Du solltest Folgendes in Rechnung stellen: 100 / 1,19 = 84,03 € in Rechnung stellen, wenn du PayPal als Auszahlungsoption wählst. Andernfalls erhältst du den vollen Betrag, wenn du auf deine cashbox (ZAP Coins) auszahlst.
-
-Wenn die Mehrwertsteuer in der Rechnung ausgewiesen werden muss, wird der volle Betrag inklusive Mehrwertsteuer in der Rechnung ausgewiesen. Bei einem Partnerguthaben von 100€ wird eine Rechnung über 100€, bestehend aus 84,03€ Rechnungsbetrag und 15,97€ MwSt., verschickt. Bei Rechnungen aus dem Ausland muss die Mehrwertsteuer in der Regel nicht auf der Rechnung ausgewiesen werden.
-:::
-
 ## Erstellen eines Affiliate-Links & Banners
+
 Um einen neuen Affiliate-Link oder Banner zu erstellen, gehst du einfach auf die [Affiliate-Hauptseite](https://zap-hosting.com/en/customer/affiliate/) und scrollst nach unten. Dort kannst du deine bestehenden Links und Banner sehen, aber auch neue über den grünen Button **Werbemittel erstellen** erstellen.
 
 ![](https://screensaver01.zap-hosting.com/index.php/s/3KTLeT7y4PzZtLS/preview)
@@ -44,6 +40,7 @@ Daraufhin öffnet sich ein Menü, in dem du eine Reihe von Werten anpassen kanns
 Die einzelnen Werte werden im Folgenden genauer erklärt:
 
 #### Alias
+
 In diesem Feld kannst du die eindeutige Alias-URL-Endung angeben, die für dein Banner oder deinen Link verwendet werden soll. Diese Endung darf nicht doppelt vorkommen, sie muss also vorhanden sein.
 
 Wenn du zum Beispiel `ilovezap` in diesem Feld angibst, bedeutet das, dass dein Banner/Link über `https://zap-hosting.com/ilovezap` erreichbar ist.
@@ -51,6 +48,7 @@ Wenn du zum Beispiel `ilovezap` in diesem Feld angibst, bedeutet das, dass dein 
 Wenn du keinen eigenen Alias angibst, wird automatisch ein zufälliger Alias für dich generiert.
 
 #### Wähle eine Vorlage oder einen Linktext
+
 Dieses Feld hängt von der Art des Werbemittels ab, das du ausgewählt hast. 
 
 Wenn du **Banner** gewählt hast, musst du eine Vorlage auswählen. Du kannst das tun, indem du das Dropdown-Menü benutzt und einen unserer vielen Standardbanner auswählst, das deinen Bedürfnissen und deinem Aussehen entspricht.
@@ -60,6 +58,7 @@ Wenn du hingegen **Link** gewählt hast, kannst du einen Linktext angeben, der v
 Du kannst das hier sehen: `<a href="https://zap-hosting.com/diesisteinaffiliatelink">Klick mich</a>`
 
 #### Auswählen des Zielprodukts
+
 In diesen Feldern kannst du eine Reihe von Optionen auswählen, um die Weiterleitung deines neuen Affiliate-Links nach deinen Wünschen zu gestalten.
 
 Wir empfehlen, die Option **Produkte kaufen** zu aktivieren, da sie den Kunden direkt zum Serverkonfigurator für das ausgewählte Produkt führt und nicht zur Produktseite. Je weniger Seiten ein Nutzer durchlaufen muss, desto wahrscheinlicher ist es, dass er eine Bestellung aufgibt.
@@ -67,6 +66,7 @@ Wir empfehlen, die Option **Produkte kaufen** zu aktivieren, da sie den Kunden d
 Als Nächstes kannst du über das Dropdown-Menü das Feld **Produkt** auswählen. Dorthin wird dein neuer Partnerlink den Nutzer weiterleiten, wenn dieser ihn aufruft. Wenn du einen Gameserver auswählst, gibt es eine zusätzliche Option **Spiel**, die du auswählen musst, ansonsten ist das Produkt die einzige Option.
 
 #### Abschluss des Erstellungsprozesses
+
 Wenn du alles nach deinen Vorstellungen ausgefüllt hast, drückst du einfach auf den grünen Button **Erstellen**, um mit der Erstellung deines Banners oder Links fortzufahren. Du solltest eine Erfolgsmeldung erhalten, wenn alles korrekt ist und dein neuer Banner oder Link erscheint unter dem Abschnitt **Deine Banner/Links**, wenn du nach unten scrollst.
 
 ![](https://screensaver01.zap-hosting.com/index.php/s/724JJWXKptMB9qR/preview)


### PR DESCRIPTION
Adjusted the affiliate guide contents, specifically removing mention of VAT-related info because the system was changed and thus this is no longer needed from the reader/user. 🙂