### PR TITLE
chore(deps): group Dependabot minor/patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,48 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
+
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: npm
+    directory: "/"
+    target-branch: master
     schedule:
-      interval: "weekly"
+      interval: weekly
+      day: monday
+      time: "05:00"
+      timezone: Europe/Berlin
+    open-pull-requests-limit: 5
+    rebase-strategy: auto
+    versioning-strategy: increase-if-necessary
+    commit-message:
+      prefix: "deps"
+      include: scope
+    labels:
+      - dependencies
+      - javascript
+    groups:
+      weekly-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    target-branch: master
+    schedule:
+      interval: weekly
+      day: tuesday
+      time: "05:00"
+      timezone: Europe/Berlin
+    open-pull-requests-limit: 5
+    rebase-strategy: auto
+    commit-message:
+      prefix: "ci"
+      include: scope
+    labels:
+      - dependencies
+      - github-actions
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Align Dependabot with zapx: group all npm minor/patch updates into a single weekly PR
- Leave major version bumps as separate PRs for intentional review
- Add github-actions updates with the same grouping pattern
- Set schedule, labels, commit prefixes, and PR limits to match the zapx setup (docs uses `master`)

## Test plan
- [ ] Confirm Dependabot config validates in the PR checks / Dependabot config UI
- [ ] After merge, wait for the next weekly run and verify one grouped `weekly-minor-patch` PR appears instead of many single-dep PRs
- [ ] Confirm a major bump (if any) still opens as its own PR


Made with [Cursor](https://cursor.com)