### PR TITLE
Fix critical websocket-driver vuln (CVE-2026-54466) (angefragt von Florian Galz)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22380,9 +22380,10 @@
       }
     },
     "node_modules/websocket-driver": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "http-parser-js": ">=0.5.1",
         "safe-buffer": ">=5.1.0",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "node": ">=18.0"
   },
   "overrides": {
-    "serialize-javascript": "^7.0.4"
+    "serialize-javascript": "^7.0.4",
+    "websocket-driver": "^0.7.5"
   }
 }


### PR DESCRIPTION
## Summary
- Closes Dependabot alert #135 (GHSA-xv26-6w52-cph6 / CVE-2026-54466, critical) — websocket-driver < 0.7.5 can be tricked into corrupting large WebSocket frame length headers.
- `websocket-driver` is a transitive dependency (webpack-dev-server -> sockjs -> faye-websocket / sockjs), so it's pinned to the patched `^0.7.5` via an npm `overrides` entry (same pattern already used for `serialize-javascript`).

## Test plan
- [x] `npm install` resolves `websocket-driver@0.7.5` for both consumers (`faye-websocket`, `sockjs`)
- [x] `npm run build` completes successfully (`[SUCCESS] Generated static files in "build/zh"`, etc.)
- [x] `git diff` limited to `package.json`/`package-lock.json`, no unrelated lockfile churn

🤖 Generated with [Claude Code](https://claude.com/claude-code)